### PR TITLE
Add lens names "fieldNameLens" using microlens

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -25,15 +25,19 @@ Library
   Exposed-modules:     Text.LLVM
                        Text.LLVM.AST
                        Text.LLVM.Labels
+                       Text.LLVM.Lens
                        Text.LLVM.Parser
                        Text.LLVM.PP
                        Text.LLVM.DebugUtils
   Other-modules:       Text.LLVM.Util
 
-  Build-depends:       base       >= 4 && < 5,
-                       containers >= 0.4,
-                       parsec     >= 3,
-                       pretty     >= 1.0.1,
-                       monadLib   >= 3.6.1
+  Build-depends:       base         >= 4 && < 5,
+                       containers   >= 0.4,
+                       parsec       >= 3,
+                       pretty       >= 1.0.1,
+                       monadLib     >= 3.6.1,
+                       microlens    >= 0.4,
+                       microlens-th >= 0.4,
+                       template-haskell >= 2.7
 
   Ghc-options:         -Wall

--- a/src/Text/LLVM/Lens.hs
+++ b/src/Text/LLVM/Lens.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Text.LLVM.Lens where
+
+import Text.LLVM
+import Lens.Micro.TH
+import Lens.Micro
+import Language.Haskell.TH.Syntax (mkName, nameBase)
+
+concat <$> mapM (makeLensesWith (lensRules & lensField .~ (\_ _ n -> [TopName $ mkName $ nameBase n ++ "Lens"])))
+    [ ''Module
+    , ''LayoutSpec
+    , ''TypeDecl
+    , ''GlobalAlias
+    , ''ConstExpr'
+    , ''Type'
+    , ''Mangling
+    , ''NamedMd
+    , ''Value'
+    , ''BlockLabel
+    , ''UnnamedMd
+    , ''Typed
+    , ''Global
+    , ''Declare
+    , ''Clause'
+    , ''FunAttr
+    , ''GlobalAttrs
+    , ''BasicBlock'
+    , ''Stmt'
+    , ''Linkage
+    , ''DebugLoc'
+    , ''DebugInfo'
+    , ''DIFile
+    , ''DISubrange
+    , ''DIBasicType
+    , ''DIExpression
+    , ''DISubprogram'
+    , ''DISubroutineType'
+    , ''DILocalVariable'
+    , ''DIGlobalVariableExpression'
+    , ''DIGlobalVariable'
+    , ''DICompileUnit'
+    , ''DICompositeType'
+    , ''DIDerivedType'
+    , ''DILexicalBlock'
+    , ''DILexicalBlockFile'
+    , ''Instr'
+    , ''ValMd'
+    , ''ConvOp
+    , ''BitOp
+    , ''ArithOp
+    , ''FCmpOp
+    , ''ICmpOp
+    , ''GC
+    , ''Define
+    , ''PrimType
+    ]


### PR DESCRIPTION
Microlens is lens-compatible and has a small fraction of the build cost, suitable for library dependencies assuming the TH dep is OK.