### PR TITLE
Bump version to account for thew new fields added to the AST

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,5 +1,5 @@
 Name:                llvm-pretty
-Version:             0.7.1.1
+Version:             0.7.2
 License:             BSD3
 License-file:        LICENSE
 Author:              Trevor Elliott


### PR DESCRIPTION
Hi,

could we merge that in, as the last commit changes the types a bit, and it would be nice to depend on the later version in the cabal file.     Also if you have time to drop a version on hackage it would be much appreciated!