### PR TITLE
Convert uses of type `String` in LLVM AST to `ByteString`.

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -32,6 +32,7 @@ Library
   Other-modules:       Text.LLVM.Util
 
   Build-depends:       base         >= 4 && < 5,
+                       bytestring   >= 0.10,
                        containers   >= 0.4,
                        parsec       >= 3,
                        pretty       >= 1.0.1,

--- a/src/Text/LLVM/Parser.hs
+++ b/src/Text/LLVM/Parser.hs
@@ -2,21 +2,29 @@ module Text.LLVM.Parser where
 
 import Text.LLVM.AST
 
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as B
+import Data.Char (isAscii, isAlphaNum)
 import Data.Int (Int32)
+import Data.Word (Word8)
 import Text.Parsec
 import Text.Parsec.String
 
 
 -- Identifiers and Symbols -----------------------------------------------------
 
-pNameChar :: Parser Char
-pNameChar = letter <|> digit <|> oneOf "-$._"
+pNameChar :: Parser Word8
+pNameChar = fromIntegral . fromEnum <$> (satisfy isAsciiAlphaNum <|> oneOf "-$._")
+  where isAsciiAlphaNum c = isAscii c && isAlphaNum c
+
+pName :: Parser ByteString
+pName = B.pack <$> many1 pNameChar
 
 pIdent :: Parser Ident
-pIdent = Ident <$> (char '%' >> many1 pNameChar)
+pIdent = Ident <$> (char '%' >> pName)
 
 pSymbol :: Parser Symbol
-pSymbol = Symbol <$> (char '@' >> many1 pNameChar)
+pSymbol = Symbol <$> (char '@' >> pName)
 
 
 -- Types -----------------------------------------------------------------------


### PR DESCRIPTION
LLVM does not know anything about UTF8 or any other text encoding;
it treats strings as just lists of bytes, and the LLVM string syntax
can encode arbitrary sequences of bytes. For this reason,
ByteString is a more honest representation of LLVM strings than
type String.

Frontends like clang may perform UTF8 encoding on names when
producing LLVM files; consumers of LLVM AST should then perform
UTF8 decoding on ByteStrings to produce a final String or Text
value.