### PR TITLE
Merge into GaloisInc/llvm-pretty

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -944,7 +944,7 @@ data Value' lab
   | ValVector Type [Value' lab]
   | ValStruct [Typed (Value' lab)]
   | ValPackedStruct [Typed (Value' lab)]
-  | ValString String
+  | ValString [Word8]
   | ValConstExpr (ConstExpr' lab)
   | ValUndef
   | ValLabel lab

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -709,7 +709,7 @@ ppValue val = case val of
   ValStruct fs       -> structBraces (commas (map (ppTyped ppValue) fs))
   ValPackedStruct fs -> angles
                       $ structBraces (commas (map (ppTyped ppValue) fs))
-  ValString s        -> char 'c' <> ppStringLiteral s
+  ValString s        -> char 'c' <> ppStringLiteral (map (toEnum . fromIntegral) s)
   ValConstExpr ce    -> ppConstExpr ce
   ValUndef           -> "undef"
   ValLabel l         -> ppLabel l


### PR DESCRIPTION
Recommend swtiching GaloisInc/saw-script back to referencing its own fork of llvm-pretty. To do this, we'll need to merge the changes from elliottt.

This is desirable as it keeps all dependencies for SAW in one place. This makes it easier to manage the mirror of the Galois github that we have recently set up.