### PR TITLE
Add DWARF address space to DIDerivedType (added in LLVM 6)

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1172,17 +1172,20 @@ data DICompositeType' lab = DICompositeType
 type DICompositeType = DICompositeType' BlockLabel
 
 data DIDerivedType' lab = DIDerivedType
-  { didtTag :: DwarfTag
-  , didtName :: Maybe String
-  , didtFile :: Maybe (ValMd' lab)
-  , didtLine :: Word32
-  , didtScope :: Maybe (ValMd' lab)
-  , didtBaseType :: Maybe (ValMd' lab)
-  , didtSize :: Word64
-  , didtAlign :: Word64
-  , didtOffset :: Word64
-  , didtFlags :: DIFlags
-  , didtExtraData :: Maybe (ValMd' lab)
+  { didtTag               :: DwarfTag
+  , didtName              :: Maybe String
+  , didtFile              :: Maybe (ValMd' lab)
+  , didtLine              :: Word32
+  , didtScope             :: Maybe (ValMd' lab)
+  , didtBaseType          :: Maybe (ValMd' lab)
+  , didtSize              :: Word64
+  , didtAlign             :: Word64
+  , didtOffset            :: Word64
+  , didtFlags             :: DIFlags
+  , didtExtraData         :: Maybe (ValMd' lab)
+  , didtDWARFAddressSpace :: Maybe Word64
+  -- ^ The 'Maybe' encodes the possibility that there is no associated address
+  -- space (in LLVM, the sentinel value @0@ is used for this).
   }
   deriving (Show,Functor,Generic,Generic1)
 


### PR DESCRIPTION
We should make an issue to track that there is no support for printing this yet.

LLVM review: https://reviews.llvm.org/D29670
Github mirror commit: https://github.com/llvm-mirror/llvm/commit/2cee5cc825969057f8d23b507a4861e606216aed
It's an unsigned int: https://github.com/llvm-mirror/llvm/blob/release_60/include/llvm/IR/DebugInfoMetadata.h#L786