### PR TITLE
Nullability in DITemplateType and DITemplateValue

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1088,7 +1088,7 @@ data DIImportedEntity' lab = DIImportedEntity
 
 type DITemplateTypeParameter = DITemplateTypeParameter' BlockLabel
 data DITemplateTypeParameter' lab = DITemplateTypeParameter
-    { dittpName :: String
+    { dittpName :: Maybe String
     , dittpType :: ValMd' lab
     } deriving (Show,Functor,Generic,Generic1)
 

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1088,15 +1088,15 @@ data DIImportedEntity' lab = DIImportedEntity
 
 type DITemplateTypeParameter = DITemplateTypeParameter' BlockLabel
 data DITemplateTypeParameter' lab = DITemplateTypeParameter
-    { dittpName :: Maybe String
-    , dittpType :: ValMd' lab
+    { dittpName :: String
+    , dittpType :: Maybe (ValMd' lab)
     } deriving (Show,Functor,Generic,Generic1)
 
 type DITemplateValueParameter = DITemplateValueParameter' BlockLabel
 data DITemplateValueParameter' lab = DITemplateValueParameter
     { ditvpName  :: String
     , ditvpType  :: ValMd' lab
-    , ditvpValue :: ValMd' lab
+    , ditvpValue :: Maybe (ValMd' lab)
     } deriving (Show,Functor,Generic,Generic1)
 
 type DINameSpace = DINameSpace' BlockLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -866,19 +866,19 @@ ppDINameSpace = ppDINameSpace' ppLabel
 
 ppDITemplateTypeParameter' :: LLVM => (i -> Doc) -> DITemplateTypeParameter' i -> Doc
 ppDITemplateTypeParameter' pp tp = "!DITemplateTypeParameter"
-  <> parens (commas [ "name:" <+> text (dittpName tp)
-                    , "type:" <+> ppValMd' pp (dittpType tp)
-                    ])
+  <> parens (mcommas [ pure ("name:" <+> text (dittpName tp))
+                     , ("type:" <+>) . ppValMd' pp <$> dittpType tp
+                     ])
 
 ppDITemplateTypeParameter :: LLVM => DITemplateTypeParameter -> Doc
 ppDITemplateTypeParameter = ppDITemplateTypeParameter' ppLabel
 
 ppDITemplateValueParameter' :: LLVM => (i -> Doc) -> DITemplateValueParameter' i -> Doc
 ppDITemplateValueParameter' pp vp = "!DITemplateValueParameter"
-  <> parens (commas [ "name:"  <+> text (ditvpName vp)
-                    , "type:"  <+> ppValMd' pp (ditvpType vp)
-                    , "value:" <+> ppValMd' pp (ditvpValue vp)
-                    ])
+  <> parens (mcommas [ pure ("name:"  <+> text (ditvpName vp))
+                     , pure ("type:"  <+> ppValMd' pp (ditvpType vp))
+                     , ("value:" <+>) . ppValMd' pp <$> ditvpValue vp
+                     ])
 
 ppDITemplateValueParameter :: LLVM => DITemplateValueParameter -> Doc
 ppDITemplateValueParameter = ppDITemplateValueParameter' ppLabel


### PR DESCRIPTION
Output from clang++ and llvm-dis 6:
```ll
!385 = !DITemplateTypeParameter(name: "_Up", type: !124)
!386 = !DITemplateTypeParameter(name: "_Ep", type: !168)
!387 = !DITemplateTypeParameter(type: null)
```

LLVM source:
 - https://github.com/llvm-mirror/llvm/blob/release_60/lib/Bitcode/Reader/MetadataLoader.cpp#L1516
 - https://github.com/llvm-mirror/llvm/blob/release_60/lib/Bitcode/Reader/MetadataLoader.cpp#L1529
