### PR TITLE
Add file field to DIImportedEntity, make diieName nullable

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,5 +1,5 @@
 Name:                llvm-pretty
-Version:             0.7.5
+Version:             0.7.6
 License:             BSD3
 License-file:        LICENSE
 Author:              Trevor Elliott

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1082,11 +1082,12 @@ type DebugInfo = DebugInfo' BlockLabel
 
 type DIImportedEntity = DIImportedEntity' BlockLabel
 data DIImportedEntity' lab = DIImportedEntity
-    { diieTag      :: DwarfTag
-    , diieName     :: String
-    , diieScope    :: Maybe (ValMd' lab)
-    , diieEntity   :: Maybe (ValMd' lab)
-    , diieLine     :: Word32
+    { diieTag    :: DwarfTag
+    , diieScope  :: Maybe (ValMd' lab)
+    , diieEntity :: Maybe (ValMd' lab)
+    , diieFile   :: Maybe (ValMd' lab)
+    , diieLine   :: Word32
+    , diieName   :: Maybe String
     } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DITemplateTypeParameter = DITemplateTypeParameter' BlockLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -844,10 +844,11 @@ ppDebugInfo = ppDebugInfo' ppLabel
 ppDIImportedEntity' :: LLVM => (i -> Doc) -> DIImportedEntity' i -> Doc
 ppDIImportedEntity' pp ie = "!DIImportedEntity"
   <> parens (mcommas [ pure ("tag:"    <+> integral (diieTag ie))
-                     , pure ("name:"   <+> text     (diieName ie))
                      , (("scope:"  <+>) . ppValMd' pp) <$> diieScope ie
                      , (("entity:" <+>) . ppValMd' pp) <$> diieEntity ie
+                     , (("file:"   <+>) . ppValMd' pp) <$> diieFile ie
                      , pure ("line:"   <+> integral (diieLine ie))
+                     , (("name:"   <+>) . text)        <$> diieName ie
                      ])
 
 ppDIImportedEntity :: LLVM => DIImportedEntity -> Doc


### PR DESCRIPTION
Also reorder the fields to match the LLVM source.

Tested with the bitcode parser, enables the previously-impossible parsing of this file: https://github.com/GaloisInc/llvm-pretty-bc-parser/blob/master/disasm-test/cpp/iostream.ll

Fixes #45