### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,5 +1,5 @@
 Name:                llvm-pretty
-Version:             0.7.7
+Version:             0.8.0
 License:             BSD3
 License-file:        LICENSE
 Author:              Trevor Elliott


### PR DESCRIPTION
The Package Version Policy (https://pvp.haskell.org/) dictates that
any API-breaking change should result in a bump of the major version number.
Unfortunately, I violated this in several of my previous PRs, bumping
only the minor versions even when the changes were breaking. This is an
attempt to patch that mistake up.