### PR TITLE
Add discriminator field to DICompositeType, bump version to 0.9.0

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,5 +1,5 @@
 Name:                llvm-pretty
-Version:             0.8.0
+Version:             0.9.0
 License:             BSD3
 License-file:        LICENSE
 Author:              Trevor Elliott
@@ -33,13 +33,13 @@ Library
                        Text.LLVM.DebugUtils
   Other-modules:       Text.LLVM.Util
 
-  Build-depends:       base         >= 4 && < 5,
-                       containers   >= 0.4,
-                       parsec       >= 3,
-                       pretty       >= 1.0.1,
-                       monadLib     >= 3.6.1,
-                       microlens    >= 0.4,
-                       microlens-th >= 0.4,
+  Build-depends:       base             >= 4 && < 5,
+                       containers       >= 0.4,
+                       parsec           >= 3,
+                       pretty           >= 1.0.1,
+                       monadLib         >= 3.6.1,
+                       microlens        >= 0.4,
+                       microlens-th     >= 0.4,
                        template-haskell >= 2.7
 
   Ghc-options:         -Wall

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1170,6 +1170,7 @@ data DICompositeType' lab = DICompositeType
   , dictVTableHolder   :: Maybe (ValMd' lab)
   , dictTemplateParams :: Maybe (ValMd' lab)
   , dictIdentifier     :: Maybe String
+  , dictDiscriminator  :: Maybe (ValMd' lab)
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DICompositeType = DICompositeType' BlockLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -940,6 +940,7 @@ ppDICompositeType' pp ct = "!DICompositeType"
        ,     (("templateParams:" <+>) . ppValMd' pp) <$> (dictTemplateParams ct)
        ,     (("identifier:"     <+>) . doubleQuotes . text)
              <$> (dictIdentifier ct)
+       ,     (("discriminator:"  <+>) . ppValMd' pp) <$> (dictDiscriminator ct)
        ])
 
 ppDICompositeType :: LLVM => DICompositeType -> Doc


### PR DESCRIPTION
Major version bump because this is an exported datatype, this would
cause breakage for anyone using this constructor downstream.

This field was added in LLVM 7.

 - Github commit: https://github.com/llvm-mirror/llvm/commit/04aa65061f79aa534463e565dbfcd1b9bb5bf13f
 - LLVM review: https://reviews.llvm.org/D42082

See also https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/105