### PR TITLE
Add an atomic ordering to the Store instruction

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,5 +1,5 @@
 Name:                llvm-pretty
-Version:             0.9.0
+Version:             0.10.0
 License:             BSD3
 License-file:        LICENSE
 Author:              Trevor Elliott

--- a/src/Text/LLVM.hs
+++ b/src/Text/LLVM.hs
@@ -634,7 +634,7 @@ load tv ma =
 store :: (IsValue a, IsValue b) => a -> Typed b -> Maybe Align -> BB ()
 store a ptr ma =
   case typedType ptr of
-    PtrTo ty -> effect (Store (ty -: a) (toValue `fmap` ptr) ma)
+    PtrTo ty -> effect (Store (ty -: a) (toValue `fmap` ptr) Nothing ma)
     _        -> error "store not given a pointer"
 
 nullPtr :: Type -> Typed Value

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -755,14 +755,16 @@ data Instr' lab
   | Load (Typed (Value' lab)) (Maybe AtomicOrdering) (Maybe Align)
     {- ^ * Read a value from the given address:
            address to read from;
+           atomic ordering;
            assumptions about alignment of the given pointer.
          * Middle of basic block.
          * Returns a value of type matching the pointer. -}
 
-  | Store (Typed (Value' lab)) (Typed (Value' lab)) (Maybe Align)
+  | Store (Typed (Value' lab)) (Typed (Value' lab)) (Maybe AtomicOrdering) (Maybe Align)
     {- ^ * Write a value to memory:
              value to store;
              pointer to location where to store;
+             atomic ordering;
              assumptions about the alignment of the given pointer.
          * Middle of basic block.
          * Effect. -}

--- a/src/Text/LLVM/DebugUtils.hs
+++ b/src/Text/LLVM/DebugUtils.hs
@@ -254,7 +254,7 @@ localVariableNameDeclarations mdMap def =
   where
 
     aux :: [Stmt] -> Map Ident Ident -> Map Ident Ident
-    aux ( Effect (Store src dst _) _
+    aux ( Effect (Store src dst _ _) _
         : Effect (Call _ _ (ValSymbol (Symbol what)) [var,md,_]) _
         : _) sofar
       | what == "llvm.dbg.declare"

--- a/src/Text/LLVM/Labels.hs
+++ b/src/Text/LLVM/Labels.hs
@@ -84,9 +84,10 @@ instance HasLabel Instr' where
                                 <$> traverse (traverse (relabel f)) n
                                 <*> pure a
   relabel f (Load a mo ma)        = Load <$> traverse (relabel f) a <*> pure mo <*> pure ma
-  relabel f (Store d v ma)        = Store
+  relabel f (Store d v mo ma)     = Store
                                 <$> traverse (relabel f) d
                                 <*> traverse (relabel f) v
+                                <*> pure mo
                                 <*> pure ma
   relabel _ (Fence s o)           = pure (Fence s o)
   relabel f (CmpXchg w v p a n s o o')


### PR DESCRIPTION
This appears as "store atomic" in LLVM bitcode. It mirrors the structure that's already present for Load.
It's been tested with the bitcode parser and produces identical output to llvm-dis.