### PR TITLE
Fix printing typo: atomicrw -> atomicrmw

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,5 +1,5 @@
 Name:                llvm-pretty
-Version:             0.10.0
+Version:             0.10.1
 License:             BSD3
 License-file:        LICENSE
 Author:              Trevor Elliott

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -506,7 +506,7 @@ ppInstr instr = case instr of
                          <+> ppScope s
                          <+> ppAtomicOrdering o
                          <+> ppAtomicOrdering o'
-  AtomicRW v op p a s o  -> "atomicrw"
+  AtomicRW v op p a s o  -> "atomicrmw"
                          <+> opt v "volatile"
                          <+> ppAtomicOp op
                          <+> ppTyped ppValue p


### PR DESCRIPTION
See: https://llvm.org/docs/LangRef.html#atomicrmw-instruction

That page has an "atomicrmw" but no "atomicrw" instruction.

From some bitcode generated by llvm-dis:
```
  %14 = atomicrmw add i32* %9, i32 %13 monotonic
  %18 = atomicrmw add i32* %9, i32 %17 acquire
  %22 = atomicrmw add i32* %9, i32 %21 release
  %26 = atomicrmw add i32* %9, i32 %25 acq_rel
```