### PR TITLE
Fix double-printing of atomicrmw value

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,5 +1,5 @@
 Name:                llvm-pretty
-Version:             0.10.1
+Version:             0.10.2
 License:             BSD3
 License-file:        LICENSE
 Author:              Trevor Elliott

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -510,7 +510,6 @@ ppInstr instr = case instr of
                          <+> opt v "volatile"
                          <+> ppAtomicOp op
                          <+> ppTyped ppValue p
-                         <> comma <+> ppTyped ppValue p
                          <> comma <+> ppTyped ppValue a
                          <+> ppScope s
                          <+> ppAtomicOrdering o


### PR DESCRIPTION
This is currently printing an instruction with three operands, instead of the expected 2.

See https://llvm.org/docs/LangRef.html#atomicrmw-instruction