### PR TITLE
Use Word32 or Word64 in LLVM types instead of Int32

### DIFF
--- a/src/Text/LLVM.hs
+++ b/src/Text/LLVM.hs
@@ -112,6 +112,7 @@ import Text.LLVM.AST
 import Control.Monad.Fix (MonadFix)
 import Data.Char (ord)
 import Data.Int (Int8,Int16,Int32,Int64)
+import Data.Word (Word32, Word64)
 import Data.Maybe (maybeToList)
 import Data.String (IsString(..))
 import MonadLib hiding (jump,Label)
@@ -413,7 +414,7 @@ terminateBasicBlock  = BB $ do
 
 -- Type Helpers ----------------------------------------------------------------
 
-iT :: Int32 -> Type
+iT :: Word32 -> Type
 iT  = PrimType . Integer
 
 ptrT :: Type -> Type
@@ -422,7 +423,7 @@ ptrT  = PtrTo
 voidT :: Type
 voidT  = PrimType Void
 
-arrayT :: Int32 -> Type -> Type
+arrayT :: Word64 -> Type -> Type
 arrayT  = Array
 
 

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -240,7 +240,7 @@ instance IsString Symbol where
 data PrimType
   = Label
   | Void
-  | Integer Int32
+  | Integer Word32
   | FloatType FloatType
   | X86mmx
   | Metadata
@@ -260,12 +260,12 @@ type Type = Type' Ident
 data Type' ident
   = PrimType PrimType
   | Alias ident
-  | Array Int32 (Type' ident)
+  | Array Word64 (Type' ident)
   | FunTy (Type' ident) [Type' ident] Bool
   | PtrTo (Type' ident)
   | Struct [Type' ident]
   | PackedStruct [Type' ident]
-  | Vector Int32 (Type' ident)
+  | Vector Word64 (Type' ident)
   | Opaque
     deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
@@ -365,11 +365,11 @@ elimPtrTo :: MonadPlus m => Type -> m Type
 elimPtrTo (PtrTo ty) = return ty
 elimPtrTo _          = mzero
 
-elimVector :: MonadPlus m => Type -> m (Int32,Type)
+elimVector :: MonadPlus m => Type -> m (Word64,Type)
 elimVector (Vector n pty) = return (n,pty)
 elimVector _              = mzero
 
-elimArray :: MonadPlus m => Type -> m (Int32, Type)
+elimArray :: MonadPlus m => Type -> m (Word64, Type)
 elimArray (Array n ety) = return (n, ety)
 elimArray _             = mzero
 
@@ -1147,7 +1147,7 @@ data DINameSpace' lab = DINameSpace
 
 -- TODO: Turn these into sum types
 -- See https://github.com/llvm-mirror/llvm/blob/release_38/include/llvm/Support/Dwarf.def
-type DwarfAttrEncoding = Word8
+type DwarfAttrEncoding = Word16
 type DwarfLang = Word16
 type DwarfTag = Word16
 type DwarfVirtuality = Word8

--- a/src/Text/LLVM/Parser.hs
+++ b/src/Text/LLVM/Parser.hs
@@ -3,7 +3,7 @@ module Text.LLVM.Parser where
 import Text.LLVM.AST
 
 import Data.Char (chr)
-import Data.Int (Int32)
+import Data.Word (Word32, Word64)
 import Text.Parsec
 import Text.Parsec.String
 
@@ -35,12 +35,15 @@ pSymbol = Symbol <$> (char '@' >> pName)
 
 -- Types -----------------------------------------------------------------------
 
-pInt32 :: Parser Int32
-pInt32 = read <$> many1 digit
+pWord32 :: Parser Word32
+pWord32 = read <$> many1 digit
+
+pWord64 :: Parser Word64
+pWord64 = read <$> many1 digit
 
 pPrimType :: Parser PrimType
 pPrimType = choice
-  [ Integer <$> try (char 'i' >> pInt32)
+  [ Integer <$> try (char 'i' >> pWord32)
   , FloatType <$> try pFloatType
   , try (string "label")    >> return Label
   , try (string "void")     >> return Void
@@ -75,9 +78,9 @@ pType = pType0 >>= pFunPtr
     pTypeList :: Parser [Type]
     pTypeList = sepBy (spaced pType) (char ',')
 
-    pNumType :: (Int32 -> Type -> Type) -> Parser Type
+    pNumType :: (Word64 -> Type -> Type) -> Parser Type
     pNumType f =
-      do n <- pInt32
+      do n <- pWord64
          spaces >> char 'x' >> spaces
          t <- pType
          return (f n t)


### PR DESCRIPTION
For integer types, LLVM seems to only support up to 2^24 bits
anyway, but it doesn't make sense to allow them to be negative.
For Array and Vector types, LLVM uses uint_64 to describe
the number of elements, so we use Word64.

I guess this probably requires a version bump, not sure what version you want to go to.