### PR TITLE
Add some new metadata fields for LLVM 11 & 12

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1184,6 +1184,11 @@ data DICompileUnit' lab = DICompileUnit
   , dicuMacros             :: Maybe (ValMd' lab)
   , dicuDWOId              :: Word64
   , dicuSplitDebugInlining :: Bool
+  , dicuDebugInfoForProf   :: Bool
+  , dicuNameTableKind      :: Word64
+  , dicuRangesBaseAddress  :: Word64
+  , dicuSysRoot            :: Maybe String
+  , dicuSDK                :: Maybe String
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DICompileUnit = DICompileUnit' BlockLabel
@@ -1205,6 +1210,7 @@ data DICompositeType' lab = DICompositeType
   , dictTemplateParams :: Maybe (ValMd' lab)
   , dictIdentifier     :: Maybe String
   , dictDiscriminator  :: Maybe (ValMd' lab)
+  , dictDataLocation   :: Maybe (ValMd' lab)
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DICompositeType = DICompositeType' BlockLabel


### PR DESCRIPTION
There are corresponding changes in `llvm-pretty-bc-parser` here: https://github.com/GaloisInc/llvm-pretty-bc-parser/commit/b11b53cee9ea7ea4c775b8aa6632dd0f249098b4
