### PR TITLE
Allow building with th-abstraction-0.4.*

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -42,6 +42,6 @@ Library
                        microlens        >= 0.4,
                        microlens-th     >= 0.4,
                        template-haskell >= 2.7,
-                       th-abstraction   >= 0.3.1 && <0.4
+                       th-abstraction   >= 0.3.1 && <0.5
 
   Ghc-options:         -Wall


### PR DESCRIPTION
This is required to make `llvm-pretty` build with GHC 9.0, as only `th-abstraction-0.4` or later support 9.0.