### PR TITLE
More visibility and linkage

### DIFF
--- a/src/Text/LLVM.hs
+++ b/src/Text/LLVM.hs
@@ -189,12 +189,14 @@ freshSymbol  = Symbol `fmap` freshNameLLVM "f"
 -- | Emit a declaration.
 declare :: Type -> Symbol -> [Type] -> Bool -> LLVM (Typed Value)
 declare rty sym tys va = emitDeclare Declare
-  { decRetType = rty
-  , decName    = sym
-  , decArgs    = tys
-  , decVarArgs = va
-  , decAttrs   = []
-  , decComdat  = Nothing
+  { decLinkage    = Nothing
+  , decVisibility = Nothing
+  , decRetType    = rty
+  , decName       = sym
+  , decArgs       = tys
+  , decVarArgs    = va
+  , decAttrs      = []
+  , decComdat     = Nothing
   }
 
 -- | Emit a global declaration.
@@ -222,14 +224,16 @@ string sym str =
 -- Function Definition ---------------------------------------------------------
 
 data FunAttrs = FunAttrs
-  { funLinkage :: Maybe Linkage
-  , funGC      :: Maybe GC
+  { funLinkage    :: Maybe Linkage
+  , funVisibility :: Maybe Visibility
+  , funGC         :: Maybe GC
   } deriving (Show)
 
 emptyFunAttrs :: FunAttrs
 emptyFunAttrs  = FunAttrs
-  { funLinkage = Nothing
-  , funGC      = Nothing
+  { funLinkage    = Nothing
+  , funVisibility = Nothing
+  , funGC         = Nothing
   }
 
 
@@ -273,17 +277,18 @@ define :: DefineArgs sig k => FunAttrs -> Type -> Symbol -> sig -> k
 define attrs rty fun sig k = do
   (args,body) <- defineBody [] sig k
   emitDefine Define
-    { defLinkage  = funLinkage attrs
-    , defName     = fun
-    , defRetType  = rty
-    , defArgs     = args
-    , defVarArgs  = False
-    , defAttrs    = []
-    , defSection  = Nothing
-    , defGC       = funGC attrs
-    , defBody     = body
-    , defMetadata = Map.empty
-    , defComdat  = Nothing
+    { defLinkage    = funLinkage attrs
+    , defVisibility = funVisibility attrs
+    , defName       = fun
+    , defRetType    = rty
+    , defArgs       = args
+    , defVarArgs    = False
+    , defAttrs      = []
+    , defSection    = Nothing
+    , defGC         = funGC attrs
+    , defBody       = body
+    , defMetadata   = Map.empty
+    , defComdat     = Nothing
     }
 
 -- | A combination of define and @freshSymbol@.
@@ -301,17 +306,18 @@ define' :: FunAttrs -> Type -> Symbol -> [Type] -> Bool
 define' attrs rty sym sig va k = do
   args <- mapM freshArg sig
   emitDefine Define
-    { defLinkage  = funLinkage attrs
-    , defName     = sym
-    , defRetType  = rty
-    , defArgs     = args
-    , defVarArgs  = va
-    , defAttrs    = []
-    , defSection  = Nothing
-    , defGC       = funGC attrs
-    , defBody     = snd (runBB (k (map (fmap toValue) args)))
-    , defMetadata = Map.empty
-    , defComdat   = Nothing
+    { defLinkage    = funLinkage attrs
+    , defVisibility = funVisibility attrs
+    , defName       = sym
+    , defRetType    = rty
+    , defArgs       = args
+    , defVarArgs    = va
+    , defAttrs      = []
+    , defSection    = Nothing
+    , defGC         = funGC attrs
+    , defBody       = snd (runBB (k (map (fmap toValue) args)))
+    , defMetadata   = Map.empty
+    , defComdat     = Nothing
     }
 
 -- Basic Block Monad -----------------------------------------------------------

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -106,9 +106,11 @@ data UnnamedMd = UnnamedMd
 -- Aliases ---------------------------------------------------------------------
 
 data GlobalAlias = GlobalAlias
-  { aliasName   :: Symbol
-  , aliasType   :: Type
-  , aliasTarget :: Value
+  { aliasLinkage    :: Maybe Linkage
+  , aliasVisibility :: Maybe Visibility
+  , aliasName       :: Symbol
+  , aliasType       :: Type
+  , aliasTarget     :: Value
   } deriving (Data, Eq, Generic, Ord, Show, Typeable)
 
 
@@ -432,12 +434,14 @@ emptyGlobalAttrs  = GlobalAttrs
 -- Declarations ----------------------------------------------------------------
 
 data Declare = Declare
-  { decRetType :: Type
-  , decName    :: Symbol
-  , decArgs    :: [Type]
-  , decVarArgs :: Bool
-  , decAttrs   :: [FunAttr]
-  , decComdat  :: Maybe String
+  { decLinkage    :: Maybe Linkage
+  , decVisibility :: Maybe Visibility
+  , decRetType    :: Type
+  , decName       :: Symbol
+  , decArgs       :: [Type]
+  , decVarArgs    :: Bool
+  , decAttrs      :: [FunAttr]
+  , decComdat     :: Maybe String
   } deriving (Data, Eq, Generic, Ord, Show, Typeable)
 
 -- | The function type of this declaration
@@ -448,17 +452,18 @@ decFunType Declare { .. } = PtrTo (FunTy decRetType decArgs decVarArgs)
 -- Function Definitions --------------------------------------------------------
 
 data Define = Define
-  { defLinkage  :: Maybe Linkage
-  , defRetType  :: Type
-  , defName     :: Symbol
-  , defArgs     :: [Typed Ident]
-  , defVarArgs  :: Bool
-  , defAttrs    :: [FunAttr]
-  , defSection  :: Maybe String
-  , defGC       :: Maybe GC
-  , defBody     :: [BasicBlock]
-  , defMetadata :: FnMdAttachments
-  , defComdat   :: Maybe String
+  { defLinkage    :: Maybe Linkage
+  , defVisibility :: Maybe Visibility
+  , defRetType    :: Type
+  , defName       :: Symbol
+  , defArgs       :: [Typed Ident]
+  , defVarArgs    :: Bool
+  , defAttrs      :: [FunAttr]
+  , defSection    :: Maybe String
+  , defGC         :: Maybe GC
+  , defBody       :: [BasicBlock]
+  , defMetadata   :: FnMdAttachments
+  , defComdat     :: Maybe String
   } deriving (Data, Eq, Generic, Ord, Show, Typeable)
 
 defFunType :: Define -> Type

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -117,7 +117,11 @@ ppUnnamedMd um =
 -- Aliases ---------------------------------------------------------------------
 
 ppGlobalAlias :: LLVM => GlobalAlias -> Doc
-ppGlobalAlias g = ppSymbol (aliasName g) <+> char '=' <+> body
+ppGlobalAlias g = ppSymbol (aliasName g)
+              <+> char '='
+              <+> ppMaybe ppLinkage (aliasLinkage g)
+              <+> ppMaybe ppVisibility (aliasVisibility g)
+              <+> body
   where
   val  = aliasTarget g
   body = case val of
@@ -276,6 +280,8 @@ ppStructGlobalAttrs ga
 
 ppDeclare :: Declare -> Doc
 ppDeclare d = "declare"
+          <+> ppMaybe ppLinkage (decLinkage d)
+          <+> ppMaybe ppVisibility (decVisibility d)
           <+> ppType (decRetType d)
           <+> ppSymbol (decName d)
            <> ppArgList (decVarArgs d) (map ppType (decArgs d))
@@ -300,6 +306,7 @@ ppSelectionKind k =
 ppDefine :: LLVM => Define -> Doc
 ppDefine d = "define"
          <+> ppMaybe ppLinkage (defLinkage d)
+         <+> ppMaybe ppVisibility (defVisibility d)
          <+> ppType (defRetType d)
          <+> ppSymbol (defName d)
           <> ppArgList (defVarArgs d) (map (ppTyped ppIdent) (defArgs d))


### PR DESCRIPTION
Fixes #77

I wasn't completely sure how to deal with the `declare` function. I could give it `FunAttrs` as argument like `define`, but `declare` doesn't have the garbage collection attribute. 

The main changes are:

   * add linkage and visibility to `Declare`
   * add visibility to `Define`
   * add linkage and visibility to `GlobalAlias` 