### PR TITLE
Support `fneg` instruction

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -657,6 +657,11 @@ isIArith _      = False
 isFArith :: ArithOp -> Bool
 isFArith  = not . isIArith
 
+data UnaryArithOp
+  = FNeg
+    -- ^ Floating point negation.
+    deriving (Data, Eq, Generic, Ord, Show, Typeable)
+
 -- | Binary bitwise operators.
 data BitOp
   = Shl Bool Bool
@@ -748,6 +753,11 @@ data Instr' lab
     {- ^ * Binary arithmetic operation, both operands have the same type.
          * Middle of basic block.
          * The result is the same as parameters. -}
+
+  | UnaryArith UnaryArithOp (Typed (Value' lab))
+    {- ^ * Unary arithmetic operation.
+         * Middle of basic block.
+         * The result is the same as the parameter. -}
 
   | Bit BitOp (Typed (Value' lab)) (Value' lab)
     {- ^ * Binary bit-vector operation, both operands have the same type.
@@ -1078,6 +1088,7 @@ data ConstExpr' lab
   | ConstFCmp FCmpOp (Typed (Value' lab)) (Typed (Value' lab))
   | ConstICmp ICmpOp (Typed (Value' lab)) (Typed (Value' lab))
   | ConstArith ArithOp (Typed (Value' lab)) (Value' lab)
+  | ConstUnaryArith UnaryArithOp (Typed (Value' lab))
   | ConstBit BitOp (Typed (Value' lab)) (Value' lab)
     deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 

--- a/src/Text/LLVM/Labels.hs
+++ b/src/Text/LLVM/Labels.hs
@@ -30,6 +30,8 @@ instance HasLabel Instr' where
   relabel f (Arith op l r)        = Arith op
                                 <$> traverse (relabel f) l
                                 <*> relabel f r
+  relabel f (UnaryArith op a)     = UnaryArith op
+                                <$> traverse (relabel f) a
   relabel f (Bit op l r)          = Bit op
                                 <$> traverse (relabel f) l
                                 <*> relabel f r

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -444,6 +444,9 @@ ppArithOp URem          = "urem"
 ppArithOp SRem          = "srem"
 ppArithOp FRem          = "frem"
 
+ppUnaryArithOp :: UnaryArithOp -> Doc
+ppUnaryArithOp FNeg = "fneg"
+
 ppBitOp :: BitOp -> Doc
 ppBitOp (Shl nuw nsw) = "shl"  <+> ppSignBits nuw nsw
 ppBitOp (Lshr e)      = "lshr" <+> ppExact e
@@ -497,6 +500,7 @@ ppInstr instr = case instr of
   RetVoid                -> "ret void"
   Arith op l r           -> ppArithOp op <+> ppTyped ppValue l
                          <> comma <+> ppValue r
+  UnaryArith op a        -> ppUnaryArithOp op <+> ppTyped ppValue a
   Bit op l r             -> ppBitOp op <+> ppTyped ppValue l
                          <> comma <+> ppValue r
   Conv op a ty           -> ppConvOp op <+> ppTyped ppValue a
@@ -834,6 +838,7 @@ ppConstExpr' pp expr =
     ConstFCmp  op a b  -> "fcmp" <+> ppFCmpOp op <+> ppTupleT a b
     ConstICmp  op a b  -> "icmp" <+> ppICmpOp op <+> ppTupleT a b
     ConstArith op a b  -> ppArithOp op <+> ppTuple a b
+    ConstUnaryArith op a -> ppUnaryArithOp op <+> ppTyp' a
     ConstBit   op a b  -> ppBitOp op   <+> ppTuple a b
   where ppTuple  a b = parens $ ppTyped ppVal' a <> comma <+> ppVal' b
         ppTupleT a b = parens $ ppTyped ppVal' a <> comma <+> ppTyp' b

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -835,11 +835,11 @@ ppConstExpr' pp expr =
     ConstSelect c l r  ->
       "select" <+> parens (commas [ ppTyp' c, ppTyp' l , ppTyp' r])
     ConstBlockAddr t l -> "blockaddress" <+> parens (ppSymbol t <> comma <+> pp l)
-    ConstFCmp  op a b  -> "fcmp" <+> ppFCmpOp op <+> ppTupleT a b
-    ConstICmp  op a b  -> "icmp" <+> ppICmpOp op <+> ppTupleT a b
-    ConstArith op a b  -> ppArithOp op <+> ppTuple a b
-    ConstUnaryArith op a -> ppUnaryArithOp op <+> ppTyp' a
-    ConstBit   op a b  -> ppBitOp op   <+> ppTuple a b
+    ConstFCmp       op a b -> "fcmp" <+> ppFCmpOp op <+> ppTupleT a b
+    ConstICmp       op a b -> "icmp" <+> ppICmpOp op <+> ppTupleT a b
+    ConstArith      op a b -> ppArithOp op <+> ppTuple a b
+    ConstUnaryArith op a   -> ppUnaryArithOp op <+> ppTyp' a
+    ConstBit        op a b -> ppBitOp op   <+> ppTuple a b
   where ppTuple  a b = parens $ ppTyped ppVal' a <> comma <+> ppVal' b
         ppTupleT a b = parens $ ppTyped ppVal' a <> comma <+> ppTyp' b
         ppVal'       = ppValue' pp


### PR DESCRIPTION
Recent versions of LLVM represent floating-point negation with a dedicated `fneg` instruction, as discovered in GaloisInc/llvm-pretty-bc-parser#148. `fneg` is considered to be a unary operation, much like the `add`, `sub`, etc. instructions are binary operations. As a result, rather than adding a dedicated `fneg` instruction, I added a `UnaryArith` instruction, which acts like (binary) `Arith` but with a single parameter. The `UnaryArithOp` data type, then, only consists of `FNeg` for now, but there could be additional operations in future versions of LLVM.