### PR TITLE
Define Lift instances for Ident, Symbol, PrimType, and FloatType

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -34,7 +34,7 @@ Library
                        Text.LLVM.DebugUtils
   Other-modules:       Text.LLVM.Util
 
-  Build-depends:       base             >= 4 && < 5,
+  Build-depends:       base             >= 4.9 && < 5,
                        containers       >= 0.4,
                        parsec           >= 3,
                        pretty           >= 1.0.1,

--- a/src/Text/LLVM.hs
+++ b/src/Text/LLVM.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE TypeOperators #-}
@@ -7,11 +6,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
 module Text.LLVM (
     -- * LLVM Monad
     LLVM()
@@ -119,10 +113,6 @@ import MonadLib hiding (jump,Label)
 import qualified Data.Foldable as F
 import qualified Data.Sequence as Seq
 import qualified Data.Map.Strict as Map
-
-#if !(MIN_VERSION_base(4,8,0))
-import Control.Applicative ( Applicative )
-#endif
 
 
 -- Fresh Names -----------------------------------------------------------------

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 module Text.LLVM.AST where
 
 import Data.Functor.Identity (Identity(..))
@@ -17,6 +18,7 @@ import Data.Semigroup as Sem
 import Data.String (IsString(fromString))
 import Data.Word (Word8,Word16,Word32,Word64)
 import GHC.Generics (Generic, Generic1)
+import Language.Haskell.TH.Syntax (Lift)
 
 import Text.Parsec
 import Text.Parsec.String
@@ -204,7 +206,7 @@ data SelectionKind = ComdatAny
 -- Identifiers -----------------------------------------------------------------
 
 newtype Ident = Ident String
-    deriving (Data, Eq, Generic, Ord, Show, Typeable)
+    deriving (Data, Eq, Generic, Ord, Show, Typeable, Lift)
 
 instance IsString Ident where
   fromString = Ident
@@ -212,7 +214,7 @@ instance IsString Ident where
 -- Symbols ---------------------------------------------------------------------
 
 newtype Symbol = Symbol String
-    deriving (Data, Eq, Generic, Ord, Show, Typeable)
+    deriving (Data, Eq, Generic, Ord, Show, Typeable, Lift)
 
 instance Sem.Semigroup Symbol where
   Symbol a <> Symbol b = Symbol (a <> b)
@@ -233,7 +235,7 @@ data PrimType
   | FloatType FloatType
   | X86mmx
   | Metadata
-    deriving (Data, Eq, Generic, Ord, Show, Typeable)
+    deriving (Data, Eq, Generic, Ord, Show, Typeable, Lift)
 
 data FloatType
   = Half
@@ -242,7 +244,7 @@ data FloatType
   | Fp128
   | X86_fp80
   | PPC_fp128
-    deriving (Data, Eq, Enum, Generic, Ord, Show, Typeable)
+    deriving (Data, Eq, Enum, Generic, Ord, Show, Typeable, Lift)
 
 type Type = Type' Ident
 

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1,14 +1,8 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveGeneric #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DeriveGeneric #-}
-
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
 module Text.LLVM.AST where
 
 import Data.Functor.Identity (Identity(..))
@@ -26,13 +20,6 @@ import GHC.Generics (Generic, Generic1)
 
 import Text.Parsec
 import Text.Parsec.String
-
-#if !(MIN_VERSION_base(4,8,0))
-import Control.Applicative ((<$))
-import Data.Foldable (Foldable(foldMap))
-import Data.Monoid (Monoid(..))
-import Data.Traversable (Traversable(sequenceA))
-#endif
 
 
 -- Modules ---------------------------------------------------------------------

--- a/src/Text/LLVM/Labels.hs
+++ b/src/Text/LLVM/Labels.hs
@@ -1,20 +1,9 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE EmptyCase, TypeOperators, FlexibleContexts #-}
-
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
 module Text.LLVM.Labels where
 
 import Text.LLVM.AST
 import Text.LLVM.Labels.TH
-
-#if !(MIN_VERSION_base(4,8,0))
-import Control.Applicative ((<$>),Applicative(..))
-import Data.Traversable (traverse)
-#endif
 
 class Functor f => HasLabel f where
   -- | Given a function for resolving labels, where the presence of a symbol


### PR DESCRIPTION
This requires the use of the `DeriveLift` extension, which needs GHC 8.0 or later. As a result, I have also included a separate commit which restricts `llvm-pretty` to only building with those versions of GHC, removing unneeded CPP in the process.

Fixes #81.