### PR TITLE
Add dict{Associated,Allocated,Rank} fields introduced in LLVM 12

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1216,6 +1216,9 @@ data DICompositeType' lab = DICompositeType
   , dictIdentifier     :: Maybe String
   , dictDiscriminator  :: Maybe (ValMd' lab)
   , dictDataLocation   :: Maybe (ValMd' lab)
+  , dictAssociated     :: Maybe (ValMd' lab)
+  , dictAllocated      :: Maybe (ValMd' lab)
+  , dictRank           :: Maybe (ValMd' lab)
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DICompositeType = DICompositeType' BlockLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -991,6 +991,9 @@ ppDICompositeType' pp ct = "!DICompositeType"
        ,     (("identifier:"     <+>) . doubleQuotes . text)
              <$> (dictIdentifier ct)
        ,     (("discriminator:"  <+>) . ppValMd' pp) <$> (dictDiscriminator ct)
+       ,     (("associated:"     <+>) . ppValMd' pp) <$> (dictAssociated ct)
+       ,     (("allocated:"      <+>) . ppValMd' pp) <$> (dictAllocated ct)
+       ,     (("rank:"           <+>) . ppValMd' pp) <$> (dictRank ct)
        ])
 
 ppDICompositeType :: LLVM => DICompositeType -> Doc


### PR DESCRIPTION
The `associated` and `allocated` fields were introduced in https://reviews.llvm.org/D83544, and the `rank` field was introduced in https://reviews.llvm.org/D89141.