### PR TITLE
Sync `DebugInfoEnumerator`'s definition with LLVM 12

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1101,7 +1101,8 @@ data DebugInfo' lab
   | DebugInfoCompileUnit (DICompileUnit' lab)
   | DebugInfoCompositeType (DICompositeType' lab)
   | DebugInfoDerivedType (DIDerivedType' lab)
-  | DebugInfoEnumerator String !Int64
+  | DebugInfoEnumerator String !Integer Bool
+    -- ^ The 'Bool' field represents @isUnsigned@, introduced in LLVM 7.
   | DebugInfoExpression DIExpression
   | DebugInfoFile DIFile
   | DebugInfoGlobalVariable (DIGlobalVariable' lab)

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -856,7 +856,7 @@ ppDebugInfo' pp di = case di of
   DebugInfoCompileUnit cu       -> ppDICompileUnit' pp cu
   DebugInfoCompositeType ct     -> ppDICompositeType' pp ct
   DebugInfoDerivedType dt       -> ppDIDerivedType' pp dt
-  DebugInfoEnumerator nm v      -> ppDIEnumerator nm v
+  DebugInfoEnumerator nm v u    -> ppDIEnumerator nm v u
   DebugInfoExpression e         -> ppDIExpression e
   DebugInfoFile f               -> ppDIFile f
   DebugInfoGlobalVariable gv    -> ppDIGlobalVariable' pp gv
@@ -1014,10 +1014,11 @@ ppDIDerivedType' pp dt = "!DIDerivedType"
 ppDIDerivedType :: LLVM => DIDerivedType -> Doc
 ppDIDerivedType = ppDIDerivedType' ppLabel
 
-ppDIEnumerator :: String -> Int64 -> Doc
-ppDIEnumerator n v = "!DIEnumerator"
+ppDIEnumerator :: String -> Integer -> Bool -> Doc
+ppDIEnumerator n v u = "!DIEnumerator"
   <> parens (commas [ "name:"  <+> doubleQuotes (text n)
                     , "value:" <+> integral v
+                    , "isUnsigned:" <+> ppBool u
                     ])
 
 ppDIExpression :: DIExpression -> Doc


### PR DESCRIPTION
This makes two changes to `DebugInfoEnumerator` to reflect its current definition as of LLVM 12:

* `DIEnumerator` now has an `isUnsigned` field as of https://reviews.llvm.org/D42734 (LLVM 7).
* `DIEnumerator` is capable of representing arbitrary-precision integers as of https://reviews.llvm.org/D62475 (LLVM 12). As a consequence, I changed the `Int64` field of `DebugInfoEnumerator` to an `Integer`.