### PR TITLE
Relax the Symbol requirement to `ConstBlockAddr`

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -993,7 +993,6 @@ data Value' lab
   | ValZeroInit
   | ValAsm Bool Bool String String
   | ValMd (ValMd' lab)
-  | ValBlockAddr (Typed (Value' lab)) lab
     deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type Value = Value' BlockLabel
@@ -1078,7 +1077,7 @@ data ConstExpr' lab
   -- ^ Element type introduced in LLVM 3.7
   | ConstConv ConvOp (Typed (Value' lab)) Type
   | ConstSelect (Typed (Value' lab)) (Typed (Value' lab)) (Typed (Value' lab))
-  | ConstBlockAddr Symbol lab
+  | ConstBlockAddr (Typed (Value' lab)) lab
   | ConstFCmp FCmpOp (Typed (Value' lab)) (Typed (Value' lab))
   | ConstICmp ICmpOp (Typed (Value' lab)) (Typed (Value' lab))
   | ConstArith ArithOp (Typed (Value' lab)) (Value' lab)

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -993,6 +993,7 @@ data Value' lab
   | ValZeroInit
   | ValAsm Bool Bool String String
   | ValMd (ValMd' lab)
+  | ValBlockAddr (Typed (Value' lab)) lab
     deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type Value = Value' BlockLabel

--- a/src/Text/LLVM/Labels.hs
+++ b/src/Text/LLVM/Labels.hs
@@ -137,5 +137,6 @@ instance HasLabel DIImportedEntity'           where relabel = $(generateRelabel 
 
 -- | Clever instance that actually uses the block name
 instance HasLabel ConstExpr' where
-  relabel f (ConstBlockAddr t l) = ConstBlockAddr t <$> f (Just t) l
+  relabel f (ConstBlockAddr t@(Typed { typedValue = ValSymbol s }) l) =
+    ConstBlockAddr <$> traverse (relabel f) t <*> f (Just s) l
   relabel f x = $(generateRelabel 'relabel ''ConstExpr') f x

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -757,7 +757,7 @@ ppValue' pp val = case val of
   ValZeroInit        -> "zeroinitializer"
   ValAsm s a i c     -> ppAsm s a i c
   ValMd m            -> ppValMd' pp m
-  ValBlockAddr a b   -> ppTyped (ppValue' pp) a <> pp b
+  ValBlockAddr a b   -> "blockaddress" <+> parens (ppTyped (ppValue' pp) a <> comma <+> pp b)
 
 ppValue :: LLVM => Value -> Doc
 ppValue = ppValue' ppLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -757,7 +757,6 @@ ppValue' pp val = case val of
   ValZeroInit        -> "zeroinitializer"
   ValAsm s a i c     -> ppAsm s a i c
   ValMd m            -> ppValMd' pp m
-  ValBlockAddr a b   -> "blockaddress" <+> parens (ppTyped (ppValue' pp) a <> comma <+> pp b)
 
 ppValue :: LLVM => Value -> Doc
 ppValue = ppValue' ppLabel
@@ -836,7 +835,7 @@ ppConstExpr' pp expr =
     ConstConv op tv t  -> ppConvOp op <+> parens (ppTyp' tv <+> "to" <+> ppType t)
     ConstSelect c l r  ->
       "select" <+> parens (commas [ ppTyp' c, ppTyp' l , ppTyp' r])
-    ConstBlockAddr t l -> "blockaddress" <+> parens (ppSymbol t <> comma <+> pp l)
+    ConstBlockAddr t l -> "blockaddress" <+> parens (ppTyped (ppValue' pp) t <> comma <+> pp l)
     ConstFCmp       op a b -> "fcmp" <+> ppFCmpOp op <+> ppTupleT a b
     ConstICmp       op a b -> "icmp" <+> ppICmpOp op <+> ppTupleT a b
     ConstArith      op a b -> ppArithOp op <+> ppTuple a b

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -757,6 +757,7 @@ ppValue' pp val = case val of
   ValZeroInit        -> "zeroinitializer"
   ValAsm s a i c     -> ppAsm s a i c
   ValMd m            -> ppValMd' pp m
+  ValBlockAddr a b   -> ppTyped (ppValue' pp) a <> pp b
 
 ppValue :: LLVM => Value -> Doc
 ppValue = ppValue' ppLabel


### PR DESCRIPTION
As part of an attempt to fix https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/149 , I believe we may need some version of `ConstBlockAddr` that is more lazy in the symbol.

That is, the value of the symbol field is a forward reference, and eagerly trying to evaluate it leads to an infinite loop.

I am not very familiar with either code bases, so I don't know whether this is the recommended way of solving such issues, but I can at least confirm that such a constructor helps with that problem.

I'd also like to make sure that this:

https://github.com/elliottt/llvm-pretty/blob/5a821ad50edc33047c75311b7d7b31bd5fc52c21/src/Text/LLVM/Labels.hs#L118

does the right generic thing corresponding to what happens here:

https://github.com/elliottt/llvm-pretty/blob/5a821ad50edc33047c75311b7d7b31bd5fc52c21/src/Text/LLVM/Labels.hs#L140