### PR TITLE
Fix a `-Wnoncanonical-monoid-instances` warning

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -57,7 +57,7 @@ instance Sem.Semigroup Module where
 
 instance Monoid Module where
   mempty = emptyModule
-  mappend m1 m2 = m1 <> m2
+  mappend = (<>)
 
 emptyModule :: Module
 emptyModule  = Module


### PR DESCRIPTION
GHC 9.2 now includes `-Wnoncanonical-monoid-instances` as a part of `-Wall`. As such, `Text.LLVM.AST` produces a warning when built with 9.2:

```
src/Text/LLVM/AST.hs:60:3: warning: [-Wnoncanonical-monoid-instances]
    Noncanonical ‘mappend’ definition detected
    in the instance declaration for ‘Monoid Module’.
    ‘mappend’ will eventually be removed in favour of ‘(<>)’
    Either remove definition for ‘mappend’ (recommended) or define as ‘mappend = (<>)’
    See also: https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid
   |
60 |   mappend m1 m2 = m1 <> m2
   |   ^^^^^^^^^^^^^^^^^^^^^^^^
```

This fixes the warning by changing the implementation of `mappend` to `mappend = (<>)`, per the warning's suggestion.