### PR TITLE
Add callbr instruction

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -764,6 +764,17 @@ data Instr' lab
          * Middle of basic block.
          * The result is as indicated by the provided type. -}
 
+  | CallBr Type (Value' lab) [Typed (Value' lab)] lab [lab]
+    {- ^ * Call a function in asm-goto style:
+             return type;
+             function operand;
+             arguments;
+             default basic block destination;
+             other basic block destinations.
+         * Middle of basic block.
+         * The result is as indicated by the provided type.
+         * Introduced in LLVM 9. -}
+
   | Alloca Type (Maybe (Typed (Value' lab))) (Maybe Int)
     {- ^ * Allocated space on the stack:
            type of elements;
@@ -943,6 +954,7 @@ isTerminator instr = case instr of
   Ret{}        -> True
   RetVoid      -> True
   Jump{}       -> True
+  CallBr{}     -> True
   Br{}         -> True
   Unreachable  -> True
   Unwind       -> True

--- a/src/Text/LLVM/Labels.hs
+++ b/src/Text/LLVM/Labels.hs
@@ -28,6 +28,11 @@ instance HasLabel Instr' where
   relabel f (Call t r n as)       = Call t r
                                 <$> relabel f n
                                 <*> traverse (traverse (relabel f)) as
+  relabel f (CallBr r n as u es)  = CallBr r
+                                <$> relabel f n
+                                <*> traverse (traverse (relabel f)) as
+                                <*> f Nothing u
+                                <*> traverse (f Nothing) es
   relabel f (Alloca t n a)        = Alloca t
                                 <$> traverse (traverse (relabel f)) n
                                 <*> pure a


### PR DESCRIPTION
This was added in LLVM 9 in commit llvm/llvm-project@784929d.

Also fix bug around printing of blockaddress constants which appear as operands to callbrs.

Bitcode parser PR: https://github.com/GaloisInc/llvm-pretty-bc-parser/pull/187