### PR TITLE
Run cabal check in CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -40,6 +40,8 @@ jobs:
       run: |
         cabal update
         cabal build --only-dependencies --enable-tests --enable-benchmarks
+    - name: Check
+      run: cabal check
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
     - name: Run tests


### PR DESCRIPTION
Since llvm-pretty is published to Hackage, we should ensure that it doesn't accumulate changes that would cause updates to be rejected. cabal check is very fast, so this doesn't add much time to CI builds.