### PR TITLE
Basic support for opaque pointers

### DIFF
--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -241,6 +241,7 @@ ppType (PrimType pt)     = ppPrimType pt
 ppType (Alias i)         = ppIdent i
 ppType (Array len ty)    = brackets (integral len <+> char 'x' <+> ppType ty)
 ppType (PtrTo ty)        = ppType ty <> char '*'
+ppType PtrOpaque         = "ptr"
 ppType (Struct ts)       = structBraces (commas (map ppType ts))
 ppType (PackedStruct ts) = angles (structBraces (commas (map ppType ts)))
 ppType (FunTy r as va)   = ppType r <> ppArgList va (map ppType as)

--- a/src/Text/LLVM/Parser.hs
+++ b/src/Text/LLVM/Parser.hs
@@ -73,6 +73,7 @@ pType = pType0 >>= pFunPtr
       , angles (braces (PackedStruct <$> pTypeList) <|> spaced (pNumType Vector))
       , string "opaque" >> return Opaque
       , PrimType <$> pPrimType
+      , string "ptr" >> return PtrOpaque
       ]
 
     pTypeList :: Parser [Type]


### PR DESCRIPTION
This is a collection of two patches that make it possible for `llvm-pretty` to handle opaque pointers and pretty-print them correctly when used in a `call` instruction, the latter of which was prompted by https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/189#issuecomment-1476068137.

This is likely not everything that we will need to handle everything opaque pointer–related, but it is a good starting point. See #102 for the long-term goal of robustly supporting opaque pointers.