### PR TITLE
Support metadata fields added in LLVM 14

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1271,6 +1271,8 @@ data DICompositeType' lab = DICompositeType
   , dictAssociated     :: Maybe (ValMd' lab)
   , dictAllocated      :: Maybe (ValMd' lab)
   , dictRank           :: Maybe (ValMd' lab)
+  , dictAnnotations    :: Maybe (ValMd' lab)
+    -- ^ Introduced in LLVM 14.
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DICompositeType = DICompositeType' BlockLabel
@@ -1292,6 +1294,8 @@ data DIDerivedType' lab = DIDerivedType
   --
   -- The 'Maybe' encodes the possibility that there is no associated address
   -- space (in LLVM, the sentinel value @0@ is used for this).
+  , didtAnnotations :: Maybe (ValMd' lab)
+  -- ^ Introduced in LLVM 14
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DIDerivedType = DIDerivedType' BlockLabel
@@ -1317,6 +1321,8 @@ data DIGlobalVariable' lab = DIGlobalVariable
   , digvVariable             :: Maybe (ValMd' lab)
   , digvDeclaration          :: Maybe (ValMd' lab)
   , digvAlignment            :: Maybe Word32
+  , digvAnnotations          :: Maybe (ValMd' lab)
+    -- ^ Introduced in LLVM 14.
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DIGlobalVariable = DIGlobalVariable' BlockLabel
@@ -1355,6 +1361,8 @@ data DILocalVariable' lab = DILocalVariable
   , dilvFlags :: DIFlags
   , dilvAlignment :: Maybe Word32
     -- ^ Introduced in LLVM 4.
+  , dilvAnnotations :: Maybe (ValMd' lab)
+    -- ^ Introduced in LLVM 14.
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DILocalVariable = DILocalVariable' BlockLabel
@@ -1380,6 +1388,8 @@ data DISubprogram' lab = DISubprogram
   , dispDeclaration    :: Maybe (ValMd' lab)
   , dispRetainedNodes  :: Maybe (ValMd' lab)
   , dispThrownTypes    :: Maybe (ValMd' lab)
+  , dispAnnotations    :: Maybe (ValMd' lab)
+    -- ^ Introduced in LLVM 14.
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DISubprogram = DISubprogram' BlockLabel

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1353,6 +1353,8 @@ data DILocalVariable' lab = DILocalVariable
   , dilvType :: Maybe (ValMd' lab)
   , dilvArg :: Word16
   , dilvFlags :: DIFlags
+  , dilvAlignment :: Maybe Word32
+    -- ^ Introduced in LLVM 4.
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DILocalVariable = DILocalVariable' BlockLabel

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1287,6 +1287,11 @@ data DIDerivedType' lab = DIDerivedType
   , didtOffset :: Word64
   , didtFlags :: DIFlags
   , didtExtraData :: Maybe (ValMd' lab)
+  , didtDwarfAddressSpace :: Maybe Word32
+  -- ^ Introduced in LLVM 5.
+  --
+  -- The 'Maybe' encodes the possibility that there is no associated address
+  -- space (in LLVM, the sentinel value @0@ is used for this).
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DIDerivedType = DIDerivedType' BlockLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1156,6 +1156,7 @@ ppDILocalVariable' pp lv = "!DILocalVariable"
        ,      (("type:"  <+>) . ppValMd' pp) <$> (dilvType lv)
        , pure ("arg:"    <+> integral (dilvArg lv))
        , pure ("flags:"  <+> integral (dilvFlags lv))
+       ,      (("align:" <+>) . integral) <$> dilvAlignment lv
        ])
 
 ppDILocalVariable :: LLVM => DILocalVariable -> Doc

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1052,6 +1052,7 @@ ppDICompositeType' pp ct = "!DICompositeType"
        ,     (("associated:"     <+>) . ppValMd' pp) <$> (dictAssociated ct)
        ,     (("allocated:"      <+>) . ppValMd' pp) <$> (dictAllocated ct)
        ,     (("rank:"           <+>) . ppValMd' pp) <$> (dictRank ct)
+       ,     (("annotations:"    <+>) . ppValMd' pp) <$> (dictAnnotations ct)
        ])
 
 ppDICompositeType :: LLVM => DICompositeType -> Doc
@@ -1071,6 +1072,7 @@ ppDIDerivedType' pp dt = "!DIDerivedType"
        , pure ("flags:"     <+> integral (didtFlags dt))
        ,     (("extraData:" <+>) . ppValMd' pp) <$> (didtExtraData dt)
        ,     (("dwarfAddressSpace:" <+>) . integral) <$> didtDwarfAddressSpace dt
+       ,     (("annotations:" <+>) . ppValMd' pp) <$> (didtAnnotations dt)
        ])
 
 ppDIDerivedType :: LLVM => DIDerivedType -> Doc
@@ -1108,6 +1110,7 @@ ppDIGlobalVariable' pp gv = "!DIGlobalVariable"
        ,      (("variable:"    <+>) . ppValMd' pp) <$> (digvVariable gv)
        ,      (("declaration:" <+>) . ppValMd' pp) <$> (digvDeclaration gv)
        ,      (("align:"       <+>) . integral) <$> digvAlignment gv
+       ,      (("annotations:" <+>) . ppValMd' pp) <$> (digvAnnotations gv)
        ])
 
 ppDIGlobalVariable :: LLVM => DIGlobalVariable -> Doc
@@ -1157,6 +1160,7 @@ ppDILocalVariable' pp lv = "!DILocalVariable"
        , pure ("arg:"    <+> integral (dilvArg lv))
        , pure ("flags:"  <+> integral (dilvFlags lv))
        ,      (("align:" <+>) . integral) <$> dilvAlignment lv
+       ,      (("annotations:" <+>) . ppValMd' pp) <$> (dilvAnnotations lv)
        ])
 
 ppDILocalVariable :: LLVM => DILocalVariable -> Doc
@@ -1189,6 +1193,7 @@ ppDISubprogram' pp sp = "!DISubprogram"
        ,      (("declaration:"    <+>) . ppValMd' pp) <$> (dispDeclaration sp)
        ,      (("retainedNodes:"  <+>) . ppValMd' pp) <$> (dispRetainedNodes sp)
        ,      (("thrownTypes:"    <+>) . ppValMd' pp) <$> (dispThrownTypes sp)
+       ,      (("annotations:"    <+>) . ppValMd' pp) <$> (dispAnnotations sp)
        ])
 
 ppDISubprogram :: LLVM => DISubprogram -> Doc

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1070,6 +1070,7 @@ ppDIDerivedType' pp dt = "!DIDerivedType"
        , pure ("offset:"    <+> integral (didtOffset dt))
        , pure ("flags:"     <+> integral (didtFlags dt))
        ,     (("extraData:" <+>) . ppValMd' pp) <$> (didtExtraData dt)
+       ,     (("dwarfAddressSpace:" <+>) . integral) <$> didtDwarfAddressSpace dt
        ])
 
 ppDIDerivedType :: LLVM => DIDerivedType -> Doc


### PR DESCRIPTION
The primary goal of this PR is to add support for `btf_tag` annotations on LLVM's metadata nodes, which are necessary to load essentially any bitcode file compiled with `clang-14 -g`. See https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/188.

This also adds support for DWARF address spaces in `DIDerivedType` (see https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/85) and alignment in `DILocalVariable` (see https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/217), both of which appear immediately before `btf_tag` annotations in their respective metadata nodes. These do not occur as often as `btf_tag` annotations do, but I added them for the sake of completeness.