### PR TITLE
More complete support for opaque pointers (required for LLVM 15+)

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -52,6 +52,7 @@ Library
                        monadLib         >= 3.6.1,
                        microlens        >= 0.4,
                        microlens-th     >= 0.4,
+                       syb              >= 0.7,
                        template-haskell >= 2.7,
                        th-abstraction   >= 0.3.1 && <0.5
 

--- a/src/Text/LLVM.hs
+++ b/src/Text/LLVM.hs
@@ -695,7 +695,7 @@ select c t f = observe (typedType t)
 
 getelementptr :: IsValue a
               => Type -> Typed a -> [Typed Value] -> BB (Typed Value)
-getelementptr ty ptr ixs = observe ty (GEP False (toValue `fmap` ptr) ixs)
+getelementptr ty ptr ixs = observe ty (GEP False ty (toValue `fmap` ptr) ixs)
 
 -- | Emit a call instruction, and generate a new variable for its result.
 call :: IsValue a => Typed a -> [Typed Value] -> BB (Typed Value)

--- a/src/Text/LLVM.hs
+++ b/src/Text/LLVM.hs
@@ -622,11 +622,8 @@ alloca ty mb align = observe (PtrTo ty) (Alloca ty es align)
   where
   es = fmap toValue `fmap` mb
 
-load :: IsValue a => Typed a -> Maybe Align -> BB (Typed Value)
-load tv ma =
-  case typedType tv of
-    PtrTo ty -> observe ty (Load (toValue `fmap` tv) Nothing ma)
-    _        -> error "load not given a pointer"
+load :: IsValue a => Type -> Typed a -> Maybe Align -> BB (Typed Value)
+load ty ptr ma = observe ty (Load ty (toValue `fmap` ptr) Nothing ma)
 
 store :: (IsValue a, IsValue b) => a -> Typed b -> Maybe Align -> BB ()
 store a ptr ma =

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -814,8 +814,9 @@ data Instr' lab
          * Middle of basic block.
          * Returns a pointer to hold the given number of elements. -}
 
-  | Load (Typed (Value' lab)) (Maybe AtomicOrdering) (Maybe Align)
+  | Load Type (Typed (Value' lab)) (Maybe AtomicOrdering) (Maybe Align)
     {- ^ * Read a value from the given address:
+           type being loaded;
            address to read from;
            atomic ordering;
            assumptions about alignment of the given pointer.

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -4,7 +4,162 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
-module Text.LLVM.AST where
+module Text.LLVM.AST
+  ( -- * Modules
+    Module(..)
+  , emptyModule
+    -- * Named Metadata
+  , NamedMd(..)
+    -- * Unnamed Metadata
+  , UnnamedMd(..)
+    -- * Aliases
+  , GlobalAlias(..)
+    -- * Data Layout
+  , DataLayout
+  , LayoutSpec(..)
+  , Mangling(..)
+  , parseDataLayout
+    -- * Inline Assembly
+  , InlineAsm
+    -- * Comdat
+  , SelectionKind(..)
+    -- * Identifiers
+  , Ident(..)
+    -- * Symbols
+  , Symbol(..)
+    -- * Types
+  , PrimType(..)
+  , FloatType(..)
+  , Type, Type'(..)
+  , updateAliasesA, updateAliases
+  , isFloatingPoint
+  , isAlias
+  , isPrimTypeOf
+  , isLabel
+  , isInteger
+  , isVector
+  , isVectorOf
+  , isArray
+  , isPointer
+  , eqTypeModuloOpaquePtrs
+  , cmpTypeModuloOpaquePtrs
+  , fixupOpaquePtrs
+    -- * Null values
+  , NullResult(..)
+  , primTypeNull
+  , floatTypeNull
+  , typeNull
+    -- * Type Elimination
+  , elimFunTy
+  , elimAlias
+  , elimPtrTo
+  , elimVector
+  , elimArray
+  , elimFunPtr
+  , elimPrimType
+  , elimFloatType
+  , elimSequentialType
+    -- * Top-level Type Aliases
+  , TypeDecl(..)
+    -- * Globals
+  , Global(..)
+  , addGlobal
+  , GlobalAttrs(..)
+  , emptyGlobalAttrs
+    -- * Declarations
+  , Declare(..)
+  , decFunType
+    -- * Function Definitions
+  , Define(..)
+  , defFunType, addDefine
+    -- * Function Attributes and attribute groups
+  , FunAttr(..)
+    -- * Basic Block Labels
+  , BlockLabel(..)
+    -- * Basic Blocks
+  , BasicBlock'(..), BasicBlock
+  , brTargets
+    -- * Attributes
+  , Linkage(..)
+  , Visibility(..)
+  , GC(..)
+    -- * Typed Things
+  , Typed(..)
+  , mapMTyped
+    -- * Instructions
+  , ArithOp(..)
+  , isIArith
+  , isFArith
+  , UnaryArithOp(..)
+  , BitOp(..)
+  , ConvOp(..)
+  , AtomicRWOp(..)
+  , AtomicOrdering(..)
+  , Align
+  , Instr'(..), Instr
+  , Clause'(..), Clause
+  , isTerminator
+  , isComment
+  , isPhi
+  , ICmpOp(..)
+  , FCmpOp(..)
+    -- * Values
+  , Value'(..), Value
+  , FP80Value(..)
+  , ValMd'(..), ValMd
+  , KindMd
+  , FnMdAttachments
+  , GlobalMdAttachments
+  , DebugLoc'(..), DebugLoc
+  , isConst
+    -- * Value Elimination
+  , elimValSymbol
+  , elimValInteger
+    -- * Statements
+  , Stmt'(..), Stmt
+  , stmtInstr
+  , stmtMetadata
+  , extendMetadata
+    -- * Constant Expressions
+  , ConstExpr'(..), ConstExpr
+    -- * DWARF Debug Info
+  , DebugInfo'(..), DebugInfo
+  , DILabel, DILabel'(..)
+  , DIImportedEntity, DIImportedEntity'(..)
+  , DITemplateTypeParameter, DITemplateTypeParameter'(..)
+  , DITemplateValueParameter, DITemplateValueParameter'(..)
+  , DINameSpace, DINameSpace'(..)
+  , DwarfAttrEncoding
+  , DwarfLang
+  , DwarfTag
+  , DwarfVirtuality
+  , DIFlags
+  , DIEmissionKind
+  , DIBasicType(..)
+  , DICompileUnit'(..), DICompileUnit
+  , DICompositeType'(..), DICompositeType
+  , DIDerivedType'(..), DIDerivedType
+  , DIExpression(..)
+  , DIFile(..)
+  , DIGlobalVariable'(..), DIGlobalVariable
+  , DIGlobalVariableExpression'(..), DIGlobalVariableExpression
+  , DILexicalBlock'(..), DILexicalBlock
+  , DILexicalBlockFile'(..), DILexicalBlockFile
+  , DILocalVariable'(..), DILocalVariable
+  , DISubprogram'(..), DISubprogram
+  , DISubrange(..)
+  , DISubroutineType'(..), DISubroutineType
+  , DIArgList'(..), DIArgList
+    -- * Aggregate Utilities
+  , IndexResult(..)
+  , isInvalid
+  , resolveGepFull
+  , resolveGep
+  , resolveGepBody
+  , isGepIndex
+  , isGepStructIndex
+  , resolveValueIndex
+  ) where
 
 import Data.Functor.Identity (Identity(..))
 import Data.Coerce (coerce)

--- a/src/Text/LLVM/Labels.hs
+++ b/src/Text/LLVM/Labels.hs
@@ -66,7 +66,7 @@ instance HasLabel Instr' where
   relabel f (FCmp op l r)         = FCmp op
                                 <$> traverse (relabel f) l
                                 <*> relabel f r
-  relabel f (GEP ib a is)         = GEP ib
+  relabel f (GEP ib t a is)       = GEP ib t
                                 <$> traverse (relabel f) a
                                 <*> traverse (traverse (relabel f)) is
   relabel f (Select c l r)        = Select

--- a/src/Text/LLVM/Labels.hs
+++ b/src/Text/LLVM/Labels.hs
@@ -36,7 +36,10 @@ instance HasLabel Instr' where
   relabel f (Alloca t n a)        = Alloca t
                                 <$> traverse (traverse (relabel f)) n
                                 <*> pure a
-  relabel f (Load a mo ma)        = Load <$> traverse (relabel f) a <*> pure mo <*> pure ma
+  relabel f (Load t a mo ma)      = Load t
+                                <$> traverse (relabel f) a
+                                <*> pure mo
+                                <*> pure ma
   relabel f (Store d v mo ma)     = Store
                                 <$> traverse (relabel f) d
                                 <*> traverse (relabel f) v

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -519,7 +519,7 @@ ppInstr instr = case instr of
   Call tc ty f args      -> ppCall tc ty f args
   CallBr ty f args u es  -> ppCallBr ty f args u es
   Alloca ty len align    -> ppAlloca ty len align
-  Load ptr mo ma         -> ppLoad ptr mo ma
+  Load ty ptr mo ma      -> ppLoad ty ptr mo ma
   Store a ptr mo ma      -> ppStore a ptr mo ma
   Fence scope order      -> "fence" <+> ppScope scope <+> ppAtomicOrdering order
   CmpXchg w v p a n s o o' -> "cmpxchg" <+> opt w "weak"
@@ -597,8 +597,8 @@ ppInstr instr = case instr of
   Resume tv           -> "resume" <+> ppTyped ppValue tv
   Freeze tv           -> "freeze" <+> ppTyped ppValue tv
 
-ppLoad :: LLVM => Typed (Value' BlockLabel) -> Maybe AtomicOrdering -> Maybe Align -> Doc
-ppLoad ptr mo ma =
+ppLoad :: LLVM => Type -> Typed (Value' BlockLabel) -> Maybe AtomicOrdering -> Maybe Align -> Doc
+ppLoad ty ptr mo ma =
   "load" <+> (if isAtomic   then "atomic" else empty)
          <+> (if isImplicit then empty    else explicit)
          <+> ppTyped ppValue ptr
@@ -615,10 +615,7 @@ ppLoad ptr mo ma =
       Just ao -> ppAtomicOrdering ao
       _       -> empty
 
-  explicit =
-    case typedType ptr of
-      PtrTo ty -> ppType ty <> comma
-      ty       -> ppType ty <> comma
+  explicit = ppType ty <> comma
 
 ppStore :: LLVM
         => Typed (Value' BlockLabel)

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -684,14 +684,10 @@ ppCall tc ty f args
 ppCallBr :: LLVM => Type -> Value -> [Typed Value] -> BlockLabel -> [BlockLabel] -> Doc
 ppCallBr ty f args to indirectDests =
   "callbr"
-     <+> ppCallSym res f <> parens (commas (map (ppTyped ppValue) args))
+     <+> ppCallSym ty f <> parens (commas (map (ppTyped ppValue) args))
      <+> "to" <+> ppLab to <+> brackets (commas (map ppLab indirectDests))
   where
     ppLab l = ppType (PrimType Label) <+> ppLabel l
-    res =
-      case ty of
-        PtrTo (FunTy r _ _) -> r
-        _ -> PrimType Void
 
 -- | Print out the @<ty>|<fnty> <fnptrval>@ portion of a @call@, @callbr@, or
 -- @invoke@ instruction, where:


### PR DESCRIPTION
This is a collection of various tweaks and additions to the `llvm-pretty` API that allow it to fully support opaque pointers, an alternative representation of pointer types that is enabled by default in LLVM 15 or later. This patch should fix #102 insofar as I have tested these changes on a reasonable subset of LLVM 15 bitcode, and this is enough to make everything that I have thrown at `llvm-pretty` work.

I have split this patch up into five self-contained commits, and for reviewing purposes, I'd recommend viewing each patch in isolation. The general themes of these patches are:

## Pretty-printing fixes

* `Fix CallBr pretty-printing w.r.t. opaque pointers`: This is a minor change to `llvm-pretty`'s pretty-printer to make it print out the function type stored directly in the `CallBr` data constructor, rather than trying to inspect the pointee type of the pointer argument (which will not exist if an opaque pointer is used).

## Storing types directly in the AST

These are the most significant changes, as they require changing the types of `Instr'` data constructors:

* `Store load type separately in Load`: We now store the load type directly rather than trying to infer it from a pointee type.
* `Store basis type separately in GEP/ConstGEP`: We now store the type used as the basis for a `getelementptr` calculation directly rather than trying to infer it from a pointee type. In the case of `ConstGEP`, this basis type corresponds to the first argument, which I have made an explicit field in `ConstGEP` for symmetry with `GEP`.

## Utilities for inspecting and manipulating opaque pointers

These commits add opaque pointer–related utilities that are essential to supporting `llvm-pretty`'s approach of allowing both opaque and non-opaque pointers.

* `Provide ability to check type equality modulo opaque pointers`: This implements `eqTypeModuloOpaquePtrs` and `cmpTypeModuloOpaquePtrs` functions that compare `Type`s, but treat `PtrOpaque` as being identical to `PtrTo`. This is extremely useful in libraries like `llvm-pretty-bc-parser` and `crucible-llvm`, which often use this notion of `Type` equality.
* `Define fixupOpaquePtrs function to support mixing opaque/non-opaque pointers`: This implements a `fixupOpaquePtrs` function that takes an `llvm-pretty` AST and, if it contains at least one opaque pointer, converts all non-opaque pointers to opaque ones. This is useful for pretty-printing purposes, as tools like `llvm-as` do not permit mixing opaque and non-opaque pointers, so this function makes it possible to still interface with these tools.