### PR TITLE
Allow building with `th-abstraction-0.5.*`

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -54,7 +54,7 @@ Library
                        microlens-th     >= 0.4,
                        syb              >= 0.7,
                        template-haskell >= 2.7,
-                       th-abstraction   >= 0.3.1 && <0.5
+                       th-abstraction   >= 0.3.1 && <0.6
 
 Test-suite llvm-pretty-test
   Import: common


### PR DESCRIPTION
This is needed to make `llvm-pretty` compatible with build plans for more recent GHCs.