### PR TITLE
Fix some minor pretty-printing bugs

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1495,7 +1495,7 @@ data DICompileUnit' lab = DICompileUnit
   , dicuSplitDebugInlining :: Bool
   , dicuDebugInfoForProf   :: Bool
   , dicuNameTableKind      :: Word64
-  , dicuRangesBaseAddress  :: Bool
+  , dicuRangesBaseAddress  :: Maybe Bool
   , dicuSysRoot            :: Maybe String
   , dicuSDK                :: Maybe String
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1008,7 +1008,7 @@ ppDICompileUnit' pp cu = "!DICompileUnit"
        , pure ("splitDebugInlining:"    <+> ppBool (dicuSplitDebugInlining cu))
        , pure ("debugInfoForProfiling:" <+> ppBool (dicuDebugInfoForProf cu))
        , pure ("nameTableKind:"         <+> integral (dicuNameTableKind cu))
-       , pure ("rangesBaseAddress:"     <+> ppBool (dicuRangesBaseAddress cu))
+       ,     (("rangesBaseAddress:"     <+>) . ppBool) <$> (dicuRangesBaseAddress cu)
        ,     (("sysroot:"               <+>) . doubleQuotes . text)
              <$> (dicuSysRoot cu)
        ,     (("sdk:"                   <+>) . doubleQuotes . text)

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -933,7 +933,7 @@ ppDIImportedEntity = ppDIImportedEntity' ppLabel
 ppDILabel' :: LLVM => (i -> Doc) -> DILabel' i -> Doc
 ppDILabel' pp ie = "!DILabel"
   <> parens (mcommas [ (("scope:"  <+>) . ppValMd' pp) <$> dilScope ie
-                     , pure ("name:" <+> text (dilName ie))
+                     , pure ("name:" <+> ppStringLiteral (dilName ie))
                      , (("file:"   <+>) . ppValMd' pp) <$> dilFile ie
                      , pure ("line:"   <+> integral (dilLine ie))
                      ])


### PR DESCRIPTION
This:

* Escapes the names of `DILabel`s in double quotes. This fixes #114.
* Makes `dicuRangesBaseAddress :: Maybe Bool` and omits pretty-printing it if is has the value `Nothing`. This fixes #113.