### PR TITLE
Fix issue #113 and #114

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       2.2
 Name:                llvm-pretty
-Version:             0.11.0.0.100
+Version:             0.11.0.0.101
 License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              Trevor Elliott

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1495,6 +1495,7 @@ data DICompileUnit' lab = DICompileUnit
   , dicuSplitDebugInlining :: Bool
   , dicuDebugInfoForProf   :: Bool
   , dicuNameTableKind      :: Word64
+    -- added in LLVM 11: dicuRangesBaseAddress, dicuSysRoot, and dicuSDK
   , dicuRangesBaseAddress  :: Bool
   , dicuSysRoot            :: Maybe String
   , dicuSDK                :: Maybe String

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1025,7 +1025,7 @@ ppDIBasicType bt = "!DIBasicType"
 
 ppDICompileUnit' :: Fmt i -> Fmt (DICompileUnit' i)
 ppDICompileUnit' pp cu = "!DICompileUnit"
-  <> parens (mcommas
+  <> parens (mcommas $
        [ pure ("language:"              <+> integral (dicuLanguage cu))
        ,     (("file:"                  <+>) . ppValMd' pp) <$> (dicuFile cu)
        ,     (("producer:"              <+>) . doubleQuotes . text)
@@ -1046,12 +1046,15 @@ ppDICompileUnit' pp cu = "!DICompileUnit"
        , pure ("splitDebugInlining:"    <+> ppBool (dicuSplitDebugInlining cu))
        , pure ("debugInfoForProfiling:" <+> ppBool (dicuDebugInfoForProf cu))
        , pure ("nameTableKind:"         <+> integral (dicuNameTableKind cu))
-       , pure ("rangesBaseAddress:"     <+> ppBool (dicuRangesBaseAddress cu))
+       ]
+       ++ if llvmVer < 11 then [] else
+       [ pure ("rangesBaseAddress:"     <+> ppBool (dicuRangesBaseAddress cu))
        ,     (("sysroot:"               <+>) . doubleQuotes . text)
              <$> (dicuSysRoot cu)
        ,     (("sdk:"                   <+>) . doubleQuotes . text)
              <$> (dicuSDK cu)
-       ])
+       ]
+       )
 
 ppDICompileUnit :: Fmt DICompileUnit
 ppDICompileUnit = ppDICompileUnit' ppLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -94,6 +94,11 @@ ppLLVM38 = withConfig Config { cfgVer = llvmV3_8 }
 llvmVer :: (?config :: Config) => LLVMVer
 llvmVer = cfgVer ?config
 
+-- | This is a helper function for when a list of parameters is gated by a
+-- condition (usually the llvmVer value).
+when' :: Monoid a => Bool -> a -> a
+when' c l = if c then l else mempty
+
 
 -- | This type encapsulates the ability to convert an object into Doc
 -- format. Using this abstraction allows for a consolidated representation of the
@@ -1045,14 +1050,15 @@ ppDICompileUnit' pp cu = "!DICompileUnit"
        , pure ("nameTableKind:"         <+> integral (dicuNameTableKind cu))
        ]
        ++
+       when' (llvmVer >= 11)
        [ pure ("rangesBaseAddress:"     <+> ppBool (dicuRangesBaseAddress cu))
        ,     (("sysroot:"               <+>) . doubleQuotes . text)
              <$> (dicuSysRoot cu)
        ,     (("sdk:"                   <+>) . doubleQuotes . text)
              <$> (dicuSDK cu)
-       | llvmVer >= 11  -- Minimum version for outputting this set of fields
        ]
        )
+
 
 ppDICompileUnit :: Fmt DICompileUnit
 ppDICompileUnit = ppDICompileUnit' ppLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -968,7 +968,7 @@ ppDIImportedEntity = ppDIImportedEntity' ppLabel
 ppDILabel' :: Fmt i -> Fmt (DILabel' i)
 ppDILabel' pp ie = "!DILabel"
   <> parens (mcommas [ (("scope:"  <+>) . ppValMd' pp) <$> dilScope ie
-                     , pure ("name:" <+> doubleQuotes (text (dilName ie)))
+                     , pure ("name:" <+> ppStringLiteral (dilName ie))
                      , (("file:"   <+>) . ppValMd' pp) <$> dilFile ie
                      , pure ("line:"   <+> integral (dilLine ie))
                      ])
@@ -1044,12 +1044,13 @@ ppDICompileUnit' pp cu = "!DICompileUnit"
        , pure ("debugInfoForProfiling:" <+> ppBool (dicuDebugInfoForProf cu))
        , pure ("nameTableKind:"         <+> integral (dicuNameTableKind cu))
        ]
-       ++ if llvmVer < 11 then [] else
+       ++
        [ pure ("rangesBaseAddress:"     <+> ppBool (dicuRangesBaseAddress cu))
        ,     (("sysroot:"               <+>) . doubleQuotes . text)
              <$> (dicuSysRoot cu)
        ,     (("sdk:"                   <+>) . doubleQuotes . text)
              <$> (dicuSDK cu)
+       | llvmVer >= 11  -- Minimum version for outputting this set of fields
        ]
        )
 

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -91,9 +91,6 @@ ppLLVM36 = withConfig Config { cfgVer = llvmV3_6 }
 ppLLVM37 = withConfig Config { cfgVer = llvmV3_7 }
 ppLLVM38 = withConfig Config { cfgVer = llvmV3_8 }
 
-checkConfig :: (?config :: Config) => (Config -> Bool) -> Bool
-checkConfig p = p ?config
-
 llvmVer :: (?config :: Config) => LLVMVer
 llvmVer = cfgVer ?config
 

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -971,7 +971,7 @@ ppDIImportedEntity = ppDIImportedEntity' ppLabel
 ppDILabel' :: Fmt i -> Fmt (DILabel' i)
 ppDILabel' pp ie = "!DILabel"
   <> parens (mcommas [ (("scope:"  <+>) . ppValMd' pp) <$> dilScope ie
-                     , pure ("name:" <+> text (dilName ie))
+                     , pure ("name:" <+> doubleQuotes (text (dilName ie)))
                      , (("file:"   <+>) . ppValMd' pp) <$> dilFile ie
                      , pure ("line:"   <+> integral (dilLine ie))
                      ])

--- a/test/Output.hs
+++ b/test/Output.hs
@@ -103,10 +103,7 @@ tests = Tasty.testGroup "LLVM pretty-printing output tests"
                                                    dwoId: 2,
                                                    splitDebugInlining: false,
                                                    debugInfoForProfiling: true,
-                                                   nameTableKind: 4,
-                                                   rangesBaseAddress: true,
-                                                   sysroot: "the root",
-                                                   sdk: "SDK")
+                                                   nameTableKind: 4)
       ----
       |]
       (ppToText $ ppLLVM35 ppStmt s1)
@@ -125,13 +122,49 @@ tests = Tasty.testGroup "LLVM pretty-printing output tests"
                                                         dwoId: 2,
                                                         splitDebugInlining: false,
                                                         debugInfoForProfiling: true,
+                                                        nameTableKind: 4)
+      ----
+      |]
+      (ppToText $ ppLLVM37 ppStmt s1)
+
+  , testCase "Stmt 1, LLVM 10" $
+    assertEqLines (ppToText $ ppLLVM 10 $ ppStmt s1) [sq|
+      No change from LLVM 3.7 through LLVM 10
+      ----
+      getelementptr inbounds %hi, opaque !DICompileUnit(language: 12,
+                                                        producer: "llvm-pretty-test",
+                                                        isOptimized: true,
+                                                        flags: "some flags",
+                                                        runtimeVersion: 3,
+                                                        emissionKind: 1,
+                                                        enums: !DITemplateTypeParameter(name: ttp),
+                                                        dwoId: 2,
+                                                        splitDebugInlining: false,
+                                                        debugInfoForProfiling: true,
+                                                        nameTableKind: 4)
+      ----
+      |]
+
+  , testCase "Stmt 1, LLVM 11" $
+    assertEqLines (ppToText $ ppLLVM 11 $ ppStmt s1) [sq|
+      In LLVM 11, DICompileUnit adds rangesBaseAddress, sysroot, and sdk
+      ----
+      getelementptr inbounds %hi, opaque !DICompileUnit(language: 12,
+                                                        producer: "llvm-pretty-test",
+                                                        isOptimized: true,
+                                                        flags: "some flags",
+                                                        runtimeVersion: 3,
+                                                        emissionKind: 1,
+                                                        enums: !DITemplateTypeParameter(name: ttp),
+                                                        dwoId: 2,
+                                                        splitDebugInlining: false,
+                                                        debugInfoForProfiling: true,
                                                         nameTableKind: 4,
                                                         rangesBaseAddress: true,
                                                         sysroot: "the root",
                                                         sdk: "SDK")
       ----
       |]
-      (ppToText $ ppLLVM37 ppStmt s1)
 
   ------------------------------------------------------------
 


### PR DESCRIPTION
Contains a fix for the quoting of the `DILabel` `name` field bug identified in Issue #114 .

Contains a fix for the `DICompileUnit` `rangesBaseAddress` (and subsequent) fields which was added in LLVM 11 as noted in Issue #113.  The fix does not switch the field type as proposed in the issue, but does update the pretty-printing.