### PR TITLE
Add `DebugInfoAssignID` (added in LLVM 17)

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1408,6 +1408,8 @@ data DebugInfo' lab
   | DebugInfoImportedEntity (DIImportedEntity' lab)
   | DebugInfoLabel (DILabel' lab)
   | DebugInfoArgList (DIArgList' lab)
+  | DebugInfoAssignID
+    -- ^ Introduced in LLVM 17.
     deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DebugInfo = DebugInfo' BlockLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -72,7 +72,7 @@ llvmV3_8 = 3
 -- this is used for defaulting and otherwise reporting the maximum LLVM version
 -- known to be supported.
 llvmVlatest :: LLVMVer
-llvmVlatest = 16
+llvmVlatest = 17
 
 
 -- | The differences between various versions of the llvm textual AST.

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -957,6 +957,7 @@ ppDebugInfo' pp di = case di of
   DebugInfoImportedEntity diip         -> ppDIImportedEntity' pp diip
   DebugInfoLabel dil            -> ppDILabel' pp dil
   DebugInfoArgList args         -> ppDIArgList' pp args
+  DebugInfoAssignID             -> "!DIAssignID()"
 
 ppDebugInfo :: Fmt DebugInfo
 ppDebugInfo = ppDebugInfo' ppLabel


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/commit/a2620e00ffa232a406de3a1d8634beeda86956fd for the LLVM commit in which this was introduced.

This is part of an eventual fix for https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/258.