### PR TITLE
Allow building with `th-abstraction-0.6.*`

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -54,7 +54,7 @@ Library
                        microlens-th     >= 0.4,
                        syb              >= 0.7,
                        template-haskell >= 2.7,
-                       th-abstraction   >= 0.3.1 && <0.6
+                       th-abstraction   >= 0.3.1 && <0.7
 
 Test-suite llvm-pretty-test
   Import: common


### PR DESCRIPTION
This is necessary to build `llvm-pretty` with `template-haskell-2.21.*`, which is bundled with GHC 9.8.