### PR TITLE
`llvm-pretty-0.12.0.0` release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for llvm-pretty
+
+## next (TBA)
+
+* Add preliminary support for LLVM versions up through 17.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Revision history for llvm-pretty
 
-## next (TBA)
+## 0.12.0.0 (January 2024)
 
 * Add preliminary support for LLVM versions up through 17.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# `llvm-pretty`
+
+A pretty printing library that was inspired by the LLVM binding by Lennart
+Augustsson. The library provides a monadic interface to a pretty printer, that
+allows functions to be defined and called, generating the corresponding LLVM
+assembly when run.
+
+## LLVM language feature support
+
+Currently, `llvm-pretty` supports LLVM versions up through 17. As a result of
+the broad version coverage, the `llvm-pretty` AST is a superset of all versions
+of the LLVM AST. This means that the manner in which certain information is
+presented in the `llvm-pretty` AST (e.g., during pretty printing) will be
+different depending on the LLVM version used to originate the information.
+Conversely, it is possible to construct an `llvm-pretty` AST that cannot be
+represented in a specific (or any) LLVM version.
+
+`llvm-pretty` strives to support a reasonable variety of [LLVM language
+features](https://llvm.org/docs/LangRef.html), but there are places where our
+coverage of the LLVM language is incomplete. If you need a LLVM feature that is
+not currently supported by `llvm-pretty`, please [file an
+issue](https://github.com/elliottt/llvm-pretty/issues/new).
+
+## `llvm-pretty` versus `llvm-pretty-bc-parser`
+
+`llvm-pretty` supports almost everything that one would want to do with LLVM
+ASTs. One notable exception is parsing: `llvm-pretty` deliberately does not
+support parsing an LLVM module AST from a bitcode file. This functionality is
+factored out into a separate
+[`llvm-pretty-bc-parser`](https://github.com/GaloisInc/llvm-pretty-bc-parser)
+library. `llvm-pretty-bc-parser` generally tries to stay in sync with all of
+the LLVM language features that `llvm-pretty` supports, but it may be the case
+that some valid `llvm-pretty` ASTs cannot be parsed by `llvm-pretty-bc-parser`.
+If you encounter an occurrence of this issue, please [file an
+issue](https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/new) at the
+`llvm-pretty-bc-parser` issue tracker.

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -4,7 +4,7 @@ Version:             0.11.0.0.101
 License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              Trevor Elliott
-Maintainer:          awesomelyawesome@gmail.com
+Maintainer:          rscott@galois.com, kquick@galois.com
 Category:            Text
 Build-type:          Simple
 Synopsis:            A pretty printing library inspired by the llvm binding.

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       2.2
 Name:                llvm-pretty
-Version:             0.11.0.0.101
+Version:             0.12.0.0
 License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              Trevor Elliott

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       2.2
 Name:                llvm-pretty
-Version:             0.12.0.0
+Version:             0.12.0.0.99
 License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              Trevor Elliott

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -14,6 +14,7 @@ Description:
   that allows functions to be defined and called, generating the corresponding
   LLVM assembly when run.
 tested-with:         GHC==8.4.3, GHC==8.2.2, GHC==8.0.2
+extra-doc-files:     CHANGELOG.md, README.md
 
 
 source-repository head


### PR DESCRIPTION
This is preparation for a Hackage release of `llvm-pretty-0.12.0.0`, which I will cut after this PR lands.