### PR TITLE
change pretty-printing of floats because of LLVM IR restrictions

### DIFF
--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -27,7 +27,7 @@ import Data.Char (isAlphaNum,isAscii,isDigit,isPrint,ord,toUpper)
 import Data.List (intersperse)
 import qualified Data.Map as Map
 import Data.Maybe (catMaybes,fromMaybe,isJust)
-import GHC.Float (castDoubleToWord64, castFloatToWord32)
+import GHC.Float (castDoubleToWord64, float2Double)
 import Numeric (showHex)
 import Text.PrettyPrint.HughesPJ
 import Data.Int
@@ -816,9 +816,11 @@ ppValue' pp val = case val of
   ValBool b          -> ppBool b
   -- Note: for +Inf/-Inf/NaNs, we want to output the bit-correct sequence
   ValFloat f         ->
-    if isInfinite f || isNaN f
-      then text "0x" <> text (showHex (castFloatToWord32 f) "")
-      else float f
+    -- WARNING: You should **not** use `castFloatToWord32` or `float` here.  LLVM IR does not
+    -- support 32-bit floating point constants, instead it wants to see 32-bit compatible 64-bit
+    -- constants.  We want to preserve the exact mantissa (zero-extended to the right from 23 to
+    -- 52 bits), which happens to be the behavior of `float2Double`.
+    text "0x" <> text (showHex (castDoubleToWord64 (float2Double f)) "")
   ValDouble d        ->
     if isInfinite d || isNaN d
       then text "0x" <> text (showHex (castDoubleToWord64 d) "")

--- a/test/Output.hs
+++ b/test/Output.hs
@@ -244,25 +244,33 @@ tests = Tasty.testGroup "LLVM pretty-printing output tests"
       --------
       |]
 
+  -- NOTE: The following tests' expected output may look surprising.  See the "WARNING" note in
+  -- `ppValue'` for details.
+
+  , testCase "Floats should use 64-bit constants" $
+    assertEqLines
+      (ppToText $ ppLLVM37 ppValue (ValFloat (castWord32ToFloat 0x42280000)))
+      "0x4045000000000000"
+
   , testCase "Positive Infinity (float)" $
     assertEqLines
       (ppToText $ ppLLVM37 ppValue (ValFloat (castWord32ToFloat 0x7F800000)))
-      "0x7f800000"
+      "0x7ff0000000000000"
 
   , testCase "Negative Infinity (float)" $
     assertEqLines
       (ppToText $ ppLLVM37 ppValue (ValFloat (castWord32ToFloat 0xFF800000)))
-      "0xff800000"
+      "0xfff0000000000000"
 
   , testCase "NaN 1 (float)" $
     assertEqLines
       (ppToText $ ppLLVM37 ppValue (ValFloat (castWord32ToFloat 0x7FC00000)))
-      "0x7fc00000"
+      "0x7ff8000000000000"
 
   , testCase "NaN 2 (float)" $
     assertEqLines
       (ppToText $ ppLLVM37 ppValue (ValFloat (castWord32ToFloat 0x7FD00000)))
-      "0x7fd00000"
+      "0x7ffa000000000000"
 
   , testCase "Positive Infinity (double)" $
     assertEqLines


### PR DESCRIPTION
As was pointed out by @tomsmeding here:
https://github.com/GaloisInc/llvm-pretty/issues/135#issuecomment-2227477305 we cannot use 32-bit (8 characters) "float" constants in LLVM IR.

Instead, we must embed the 32-bit float as 64-bit double constants with the same meaning.