### PR TITLE
Support more `AtomicRWOp`s

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1,7 +1,7 @@
 {- |
 Because this library supports many LLVM versions, it is possible to construct
 an AST with the types in this module that only some LLVM versions will accept.
-These cases are usually documented in the haddocks for the relevant data types.
+These cases are usually documented in the Haddocks for the relevant data types.
 When trying to pretty-print constructions that are unsupported by the current
 LLVM version, pretty-printing may 'error'.
 

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1,3 +1,14 @@
+{- |
+Because this library supports many LLVM versions, it is possible to construct
+an AST with the types in this module that only some LLVM versions will accept.
+These cases are usually documented in the haddocks for the relevant data types.
+When trying to pretty-print constructions that are unsupported by the current
+LLVM version, pretty-printing may 'error'.
+
+At the same time, while the AST coverage is fairly extensive, it is also
+incomplete: there are some values that new LLVM versions would accept but are
+not yet represented here.
+-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveGeneric #-}
 {-# LANGUAGE PatternGuards #-}
@@ -982,10 +993,6 @@ data ConvOp
   | BitCast
     deriving (Data, Eq, Enum, Generic, Ord, Show, Typeable)
 
--- | Some of the atomic RW operations are supported only on later LLVM
--- versions. Because the LLVM version is chosen dynamically, the data
--- constructors cannot be excluded statically; pretty-printing for an LLVM
--- version that does not support the operation will call 'error'.
 data AtomicRWOp
   = AtomicXchg
   | AtomicAdd

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1005,12 +1005,12 @@ data AtomicRWOp
   | AtomicMin
   | AtomicUMax
   | AtomicUMin
-  | AtomicFAdd  -- ^ LLVM >= 9
-  | AtomicFSub  -- ^ LLVM >= 9
-  | AtomicFMax  -- ^ LLVM >= 15
-  | AtomicFMin  -- ^ LLVM >= 15
-  | AtomicUIncWrap  -- ^ LLVM >= 16
-  | AtomicUDecWrap  -- ^ LLVM >= 16
+  | AtomicFAdd  -- ^ Introduced in LLVM 9
+  | AtomicFSub  -- ^ Introduced in LLVM 9
+  | AtomicFMax  -- ^ Introduced in LLVM 15
+  | AtomicFMin  -- ^ Introduced in LLVM 15
+  | AtomicUIncWrap  -- ^ Introduced in LLVM 16
+  | AtomicUDecWrap  -- ^ Introduced in LLVM 16
     deriving (Data, Eq, Enum, Generic, Ord, Show, Typeable)
 
 data AtomicOrdering

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -982,6 +982,10 @@ data ConvOp
   | BitCast
     deriving (Data, Eq, Enum, Generic, Ord, Show, Typeable)
 
+-- | Some of the atomic RW operations are supported only on later LLVM
+-- versions. Because the LLVM version is chosen dynamically, the data
+-- constructors cannot be excluded statically; pretty-printing for an LLVM
+-- version that does not support the operation will call 'error'.
 data AtomicRWOp
   = AtomicXchg
   | AtomicAdd
@@ -994,6 +998,12 @@ data AtomicRWOp
   | AtomicMin
   | AtomicUMax
   | AtomicUMin
+  | AtomicFAdd  -- ^ LLVM >= 9
+  | AtomicFSub  -- ^ LLVM >= 9
+  | AtomicFMax  -- ^ LLVM >= 15
+  | AtomicFMin  -- ^ LLVM >= 15
+  | AtomicUIncWrap  -- ^ LLVM >= 16
+  | AtomicUDecWrap  -- ^ LLVM >= 16
     deriving (Data, Eq, Enum, Generic, Ord, Show, Typeable)
 
 data AtomicOrdering

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1369,8 +1369,8 @@ structBraces body = char '{' <+> body <+> char '}'
 ppMaybe :: Fmt a -> Fmt (Maybe a)
 ppMaybe  = maybe empty
 
--- | Throw an error if the ?config version is older than the given version. The
--- String indicates the constructor that is unavailable.
+-- | Throw an error if the @?config@ version is older than the given version. The
+-- String indicates which constructor is unavailable in the error message.
 onlyOnLLVM :: (?config :: Config) => LLVMVer -> String -> a -> a
 onlyOnLLVM fromVer name
   | llvmVer >= fromVer = id

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -96,6 +96,15 @@ ppLLVM38 = withConfig Config { cfgVer = llvmV3_8 }
 llvmVer :: (?config :: Config) => LLVMVer
 llvmVer = cfgVer ?config
 
+llvmVerToString :: LLVMVer -> String
+llvmVerToString 0 = "3.5"
+llvmVerToString 1 = "3.6"
+llvmVerToString 2 = "3.7"
+llvmVerToString 3 = "3.8"
+llvmVerToString n
+  | n >= 4    = show n
+  | otherwise = error $ "Invalid LLVMVer: " ++ show n
+
 -- | This is a helper function for when a list of parameters is gated by a
 -- condition (usually the llvmVer value).
 when' :: Monoid a => Bool -> a -> a
@@ -547,6 +556,12 @@ ppAtomicOp AtomicMax  = "max"
 ppAtomicOp AtomicMin  = "min"
 ppAtomicOp AtomicUMax = "umax"
 ppAtomicOp AtomicUMin = "umin"
+ppAtomicOp AtomicFAdd = onlyOnLLVM 9 "AtomicFAdd" "fadd"
+ppAtomicOp AtomicFSub = onlyOnLLVM 9 "AtomicFSub" "fsub"
+ppAtomicOp AtomicFMax = onlyOnLLVM 15 "AtomicFMax" "fmax"
+ppAtomicOp AtomicFMin = onlyOnLLVM 15 "AtomicFMin" "fmin"
+ppAtomicOp AtomicUIncWrap = onlyOnLLVM 16 "AtomicUIncWrap" "uincwrap"
+ppAtomicOp AtomicUDecWrap = onlyOnLLVM 16 "AtomicUDecWrap" "udecwrap"
 
 ppScope ::  Fmt (Maybe String)
 ppScope Nothing = empty
@@ -1353,3 +1368,11 @@ structBraces body = char '{' <+> body <+> char '}'
 
 ppMaybe :: Fmt a -> Fmt (Maybe a)
 ppMaybe  = maybe empty
+
+-- | Throw an error if the ?config version is older than the given version. The
+-- String indicates the constructor that is unavailable.
+onlyOnLLVM :: (?config :: Config) => LLVMVer -> String -> a -> a
+onlyOnLLVM fromVer name
+  | llvmVer >= fromVer = id
+  | otherwise          = error $ name ++ " is supported only on LLVM >= "
+                                 ++ llvmVerToString fromVer


### PR DESCRIPTION
The current list of operations for `atomicrmw` (`AtomicRWOp`) was up to date for LLVM 8, but since then more operations have been added. By now (LLVM 19), 6 more have arrived ([documentation](https://llvm.org/docs/LangRef.html#atomicrmw-instruction)). This PR adds them, and predicates their pretty-printing on the minimum LLVM version that has them.

Caveats:
1. Because data constructors are declared at compile time and we only know the target LLVM version at runtime, all we can do is `error` if an operation is used that the target LLVM version does not support. This is unfortunate, but I don't see a better option here.
2. I deduced minimum LLVM versions simply by looking at the LLVM LangRef documentation for `atomicrmw` for a whole bunch of LLVM versions. I did not actually test that the documentation corresponds with reality.

(Context: as an experiment, I'm trying to convert the [Accelerate LLVM backend](https://github.com/AccelerateHS/accelerate-llvm) to use `llvm-pretty` instead of the `llvm-hs` bindings with the aim of reducing maintenance overhead for the Accelerate maintainers. No guarantees that we'll actually be merging this migration.)