### PR TITLE
Allow building with `th-abstraction-0.7.*`

### DIFF
--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -55,7 +55,7 @@ Library
                        microlens-th     >= 0.4,
                        syb              >= 0.7,
                        template-haskell >= 2.7,
-                       th-abstraction   >= 0.3.1 && <0.7
+                       th-abstraction   >= 0.3.1 && <0.8
 
 Test-suite llvm-pretty-test
   Import: common


### PR DESCRIPTION
This makes it easier to obtain a build plan that is compatible with GHC 9.10.