### PR TITLE
Add support for LLVM address spaces

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -93,6 +93,7 @@ module Text.LLVM.AST
     -- * Attributes
   , Linkage(..)
   , Visibility(..)
+  , ThreadLocality(..)
   , UnnamedAddr(..)
   , AddrSpace(..)
   , allocaAddrSpace
@@ -723,6 +724,7 @@ addGlobal g m = m { modGlobals = g : modGlobals m }
 data GlobalAttrs = GlobalAttrs
   { gaLinkage    :: Maybe Linkage
   , gaVisibility :: Maybe Visibility
+  , gaThreadLocality :: Maybe ThreadLocality
   , gaUnnamedAddr :: Maybe UnnamedAddr
   , gaAddrSpace  :: AddrSpace
   , gaConstant   :: Bool
@@ -871,6 +873,13 @@ data Linkage
 data Visibility = DefaultVisibility
                 | HiddenVisibility
                 | ProtectedVisibility
+    deriving (Data, Eq, Generic, Ord, Show, Typeable)
+
+data ThreadLocality = NotThreadLocal
+                | ThreadLocal
+                | LocalDynamic
+                | InitialExec
+                | LocalExec
     deriving (Data, Eq, Generic, Ord, Show, Typeable)
 
 -- ^ there is also None, use Nothing for it

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -394,7 +394,18 @@ data SelectionKind = ComdatAny
 -- Identifiers -----------------------------------------------------------------
 
 newtype Ident = Ident String
-    deriving (Data, Eq, Generic, Ord, Show, Typeable, Lift)
+    deriving (Data, Eq, Generic, Show, Typeable, Lift)
+
+-- this exists so that struct types will be printed in the same order llvm-dis prints them
+instance Ord Ident where
+  compare (Ident l) (Ident r) = go l r where
+    go [] [] = EQ
+    go [] _ = GT
+    go _ [] = LT
+    go (ll:ls) (rr:rs) = case compare ll rr of
+      LT -> LT
+      GT -> GT
+      EQ -> go ls rs
 
 instance IsString Ident where
   fromString = Ident

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -93,6 +93,11 @@ module Text.LLVM.AST
     -- * Attributes
   , Linkage(..)
   , Visibility(..)
+  , UnnamedAddr(..)
+  , AddrSpace(..)
+  , allocaAddrSpace
+  , programAddrSpace
+  , ptrAddrSpace
   , GC(..)
     -- * Typed Things
   , Typed(..)
@@ -284,7 +289,7 @@ type DataLayout = [LayoutSpec]
 data LayoutSpec
   = BigEndian
   | LittleEndian
-  | PointerSize   !Int !Int !Int (Maybe Int) -- ^ address space, size, abi, pref
+  | PointerSize   !Bool !Int !Int !Int (Maybe Int) (Maybe Int) -- ^ fat pointer?, address space, size, abi, pref, "size of index used in GEP for address calculation"
   | IntegerSize   !Int !Int (Maybe Int) -- ^ size, abi, pref
   | VectorSize    !Int !Int (Maybe Int) -- ^ size, abi, pref
   | FloatSize     !Int !Int (Maybe Int) -- ^ size, abi, pref
@@ -293,6 +298,9 @@ data LayoutSpec
   | NativeIntSize [Int]
   | StackAlign    !Int -- ^ size
   | Mangling Mangling
+  | AllocaAddressSpace !AddrSpace
+  | DefaultGlobalVariableAddressSpace !AddrSpace
+  | ProgramAddressSpace !AddrSpace -- ^ program address space, in particular functions
     deriving (Data, Eq, Generic, Ord, Show, Typeable)
 
 data Mangling = ElfMangling
@@ -318,7 +326,7 @@ parseDataLayout str =
            'E' -> return BigEndian
            'e' -> return LittleEndian
            'S' -> StackAlign    <$> pInt
-           'p' -> PointerSize   <$> pInt0 <*> pCInt <*> pCInt <*> pPref
+           'p' -> PointerSize   <$> pFat <*> pInt0 <*> pCInt <*> pCInt <*> pPref <*> pPref
            'i' -> IntegerSize   <$> pInt <*> pCInt <*> pPref
            'v' -> VectorSize    <$> pInt <*> pCInt <*> pPref
            'f' -> FloatSize     <$> pInt <*> pCInt <*> pPref  -- size of float, abi-align, pref-align
@@ -340,6 +348,9 @@ parseDataLayout str =
            'a' -> AggregateSize <$> pInt <*> pCInt <*> pPref
            'n' -> NativeIntSize <$> sepBy pInt (char ':')
            'm' -> Mangling      <$> (char ':' >> pMangling)
+           'A' -> AllocaAddressSpace                . AddrSpace <$> pInt
+           'G' -> DefaultGlobalVariableAddressSpace . AddrSpace <$> pInt
+           'P' -> ProgramAddressSpace               . AddrSpace <$> pInt
            _   -> mzero
 
     pMangling :: Parser Mangling
@@ -360,6 +371,9 @@ parseDataLayout str =
 
     pCInt :: Parser Int
     pCInt = char ':' >> pInt
+
+    pFat :: Parser Bool
+    pFat = (char 'f' *> return True) <|> return False
 
     pPref :: Parser (Maybe Int)
     pPref = optionMaybe pCInt
@@ -427,20 +441,20 @@ data Type' ident
   | Alias ident
   | Array Word64 (Type' ident)
   | FunTy (Type' ident) [Type' ident] Bool
-  | PtrTo (Type' ident)
+  | PtrTo !AddrSpace (Type' ident)
     -- ^ A pointer to a memory location of a particular type. See also
     -- 'PtrOpaque', which represents a pointer without a pointee type.
     --
-    -- LLVM pointers can also have an optional address space attribute, but this
-    -- is not currently represented in the @llvm-pretty@ AST.
-  | PtrOpaque
+    -- LLVM pointers also have an optional address space attribute defaulting
+    -- to 0.
+  | PtrOpaque !AddrSpace
     -- ^ A pointer to a memory location. Unlike 'PtrTo', a 'PtrOpaque' does not
     -- have a pointee type. Instead, instructions interacting through opaque
     -- pointers specify the type of the underlying memory they are interacting
     -- with.
     --
-    -- LLVM pointers can also have an optional address space attribute, but this
-    -- is not currently represented in the @llvm-pretty@ AST.
+    -- LLVM pointers also have an optional address space attribute defaulting to
+    -- 0.
     --
     -- 'PtrOpaque' should not be confused with 'Opaque', which is a completely
     -- separate type with a similar-sounding name.
@@ -463,8 +477,8 @@ updateAliasesA f = loop
   loop ty = case ty of
     Array len ety    -> Array len    <$> (loop ety)
     FunTy res ps var -> FunTy        <$> (loop res) <*> (traverse loop ps) <*> pure var
-    PtrTo pty        -> PtrTo        <$> (loop pty)
-    PtrOpaque        -> pure PtrOpaque
+    PtrTo adr pty    -> PtrTo adr    <$> (loop pty)
+    PtrOpaque adr    -> pure $ PtrOpaque adr
     Struct fs        -> Struct       <$> (traverse loop fs)
     PackedStruct fs  -> PackedStruct <$> (traverse loop fs)
     Vector len ety   -> Vector       <$> pure len <*> (loop ety)
@@ -510,8 +524,8 @@ isArray ty = case ty of
   _         -> False
 
 isPointer :: Type -> Bool
-isPointer (PtrTo _) = True
-isPointer PtrOpaque = True
+isPointer (PtrTo _ _) = True
+isPointer (PtrOpaque _) = True
 isPointer _         = False
 
 
@@ -545,8 +559,8 @@ data TypeView' ident
 -- | Convert a `Type'` value to a `TypeView'` value.
 typeView :: Type' ident -> TypeView' ident
 -- The two most important cases. Both forms of pointers are mapped to PtrView.
-typeView (PtrTo _)           = PtrView
-typeView PtrOpaque           = PtrView
+typeView (PtrTo _ _)         = PtrView
+typeView (PtrOpaque _)       = PtrView
 -- All other cases are straightforward.
 typeView (PrimType pt)       = PrimTypeView pt
 typeView (Alias lab)         = AliasView lab
@@ -592,11 +606,11 @@ fixupOpaquePtrs m
     = m
   where
     isOpaquePtr :: Type -> Bool
-    isOpaquePtr PtrOpaque = True
+    isOpaquePtr (PtrOpaque _) = True
     isOpaquePtr _         = False
 
     opaquifyPtr :: Type -> Type
-    opaquifyPtr (PtrTo _) = PtrOpaque
+    opaquifyPtr (PtrTo adr _) = PtrOpaque adr
     opaquifyPtr t         = t
 
     -- Find the first occurrence of a @b@ value within the @a@ value that
@@ -627,7 +641,7 @@ floatTypeNull _        = error "must be a float type"
 typeNull :: Type -> NullResult lab
 typeNull (PrimType pt) = HasNull (primTypeNull pt)
 typeNull PtrTo{}       = HasNull ValNull
-typeNull PtrOpaque     = HasNull ValNull
+typeNull PtrOpaque{}   = HasNull ValNull
 typeNull (Alias i)     = ResolveNull i
 typeNull _             = HasNull ValZeroInit
 
@@ -642,7 +656,7 @@ elimAlias (Alias i) = return i
 elimAlias _         = mzero
 
 elimPtrTo :: MonadPlus m => Type -> m Type
-elimPtrTo (PtrTo ty) = return ty
+elimPtrTo (PtrTo _ ty) = return ty
 elimPtrTo _          = mzero
 
 elimVector :: MonadPlus m => Type -> m (Word64,Type)
@@ -668,7 +682,7 @@ elimFloatType _              = mzero
 elimSequentialType :: MonadPlus m => Type -> m Type
 elimSequentialType ty = case ty of
   Array _ elTy -> return elTy
-  PtrTo elTy   -> return elTy
+  PtrTo _ elTy -> return elTy
   Vector _ pty -> return pty
   _            -> mzero
 
@@ -698,6 +712,8 @@ addGlobal g m = m { modGlobals = g : modGlobals m }
 data GlobalAttrs = GlobalAttrs
   { gaLinkage    :: Maybe Linkage
   , gaVisibility :: Maybe Visibility
+  , gaUnnamedAddr :: Maybe UnnamedAddr
+  , gaAddrSpace  :: AddrSpace
   , gaConstant   :: Bool
   } deriving (Data, Eq, Generic, Ord, Show, Typeable)
 
@@ -705,6 +721,8 @@ emptyGlobalAttrs :: GlobalAttrs
 emptyGlobalAttrs  = GlobalAttrs
   { gaLinkage    = Nothing
   , gaVisibility = Nothing
+  , gaUnnamedAddr = Nothing
+  , gaAddrSpace  = AddrSpace 0
   , gaConstant   = False
   }
 
@@ -714,17 +732,19 @@ emptyGlobalAttrs  = GlobalAttrs
 data Declare = Declare
   { decLinkage    :: Maybe Linkage
   , decVisibility :: Maybe Visibility
+  , decUnnamedAddr :: Maybe UnnamedAddr
   , decRetType    :: Type
   , decName       :: Symbol
   , decArgs       :: [Type]
   , decVarArgs    :: Bool
   , decAttrs      :: [FunAttr]
   , decComdat     :: Maybe String
+  , decAddrSpace  :: AddrSpace
   } deriving (Data, Eq, Generic, Ord, Show, Typeable)
 
 -- | The function type of this declaration
 decFunType :: Declare -> Type
-decFunType Declare { .. } = PtrTo (FunTy decRetType decArgs decVarArgs)
+decFunType Declare { .. } = PtrTo decAddrSpace (FunTy decRetType decArgs decVarArgs)
 
 
 -- Function Definitions --------------------------------------------------------
@@ -732,6 +752,7 @@ decFunType Declare { .. } = PtrTo (FunTy decRetType decArgs decVarArgs)
 data Define = Define
   { defLinkage    :: Maybe Linkage
   , defVisibility :: Maybe Visibility
+  , defAddrSpace  :: AddrSpace
   , defRetType    :: Type
   , defName       :: Symbol
   , defArgs       :: [Typed Ident]
@@ -746,7 +767,7 @@ data Define = Define
 
 defFunType :: Define -> Type
 defFunType Define { .. } =
-  PtrTo (FunTy defRetType (map typedType defArgs) defVarArgs)
+  PtrTo defAddrSpace (FunTy defRetType (map typedType defArgs) defVarArgs)
 
 addDefine :: Define -> Module -> Module
 addDefine d m = m { modDefines = d : modDefines m }
@@ -840,6 +861,15 @@ data Visibility = DefaultVisibility
                 | HiddenVisibility
                 | ProtectedVisibility
     deriving (Data, Eq, Generic, Ord, Show, Typeable)
+
+-- ^ there is also None, use Nothing for it
+data UnnamedAddr = GlobalUnnamedAddr
+                 | LocalUnnamedAddr
+    deriving (Data, Eq, Generic, Ord, Show, Typeable)
+
+newtype AddrSpace = AddrSpace
+  { getAddrSpace :: Int
+  } deriving (Data, Eq, Generic, Ord, Show, Typeable) -- , Bits, FiniteBits)
 
 newtype GC = GC
   { getGC :: String
@@ -1070,8 +1100,9 @@ data Instr' lab
          * The result is as indicated by the provided type.
          * Introduced in LLVM 9. -}
 
-  | Alloca Type (Maybe (Typed (Value' lab))) (Maybe Int)
+  | Alloca Type AddrSpace (Maybe (Typed (Value' lab))) (Maybe Int)
     {- ^ * Allocated space on the stack:
+           address space;
            type of elements;
            how many elements (1 if 'Nothing');
            required alignment.
@@ -1822,3 +1853,21 @@ resolveValueIndex ty is@(ix:ixs) = case ty of
 
   _ -> Invalid
 resolveValueIndex ty [] = HasType ty
+
+allocaAddrSpace :: DataLayout -> AddrSpace
+allocaAddrSpace [] = AddrSpace 0
+allocaAddrSpace (AllocaAddressSpace as:_) = as
+allocaAddrSpace (_:ds) = allocaAddrSpace ds
+
+programAddrSpace :: DataLayout -> AddrSpace
+programAddrSpace [] = AddrSpace 0
+programAddrSpace (ProgramAddressSpace as:_) = as
+programAddrSpace (_:ds) = programAddrSpace ds
+
+ptrAddrSpace :: Typed a -> AddrSpace
+ptrAddrSpace = go . typedType
+  where
+    go :: Type -> AddrSpace
+    go (PtrTo x _) = x
+    go (PtrOpaque x) = x
+    go _ = AddrSpace 0

--- a/src/Text/LLVM/Labels.hs
+++ b/src/Text/LLVM/Labels.hs
@@ -33,7 +33,7 @@ instance HasLabel Instr' where
                                 <*> traverse (traverse (relabel f)) as
                                 <*> f Nothing u
                                 <*> traverse (f Nothing) es
-  relabel f (Alloca t n a)        = Alloca t
+  relabel f (Alloca t s n a)      = Alloca t s
                                 <$> traverse (traverse (relabel f)) n
                                 <*> pure a
   relabel f (Load t a mo ma)      = Load t

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1390,7 +1390,7 @@ ppInt64ValMd' canFallBack pp = go
 
 
 commas :: Fmt [Doc]
-commas  = hsep . punctuate comma
+commas  = fsep . punctuate comma
 
 -- | Helpful for all of the optional fields that appear in the
 -- metadata values

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -357,6 +357,7 @@ ppGlobalAttrs hasValue ga
         constant
     | otherwise =
         ppMaybe ppLinkage (gaLinkage ga) <+>
+        ppMaybe ppThreadLocality (gaThreadLocality ga) <+>
         ppMaybe ppVisibility (gaVisibility ga) <+>
         ppMaybe ppUnnamedAddr (gaUnnamedAddr ga) <+>
         ppAddrSpace (gaAddrSpace ga) <+>
@@ -503,6 +504,14 @@ ppVisibility v = case v of
     DefaultVisibility   -> empty
     HiddenVisibility    -> "hidden"
     ProtectedVisibility -> "protected"
+
+ppThreadLocality :: Fmt ThreadLocality
+ppThreadLocality v = case v of
+  NotThreadLocal -> empty
+  ThreadLocal -> "thread_local"
+  LocalDynamic -> "localdynamic"
+  InitialExec -> "initialexec"
+  LocalExec -> "localexec"
 
 ppGC :: Fmt GC
 ppGC  = doubleQuotes . text . getGC

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -975,7 +975,7 @@ ppConstExpr' pp expr =
     ConstArith      op a b -> ppArithOp op <+> ppTuple a b
     ConstUnaryArith op a   -> ppUnaryArithOp op <+> ppTyp' a
     ConstBit        op a b -> ppBitOp op   <+> ppTuple a b
-  where ppTuple  a b = parens $ ppTyped ppVal' a <> comma <+> ppVal' b
+  where ppTuple  a b = parens $ ppTyped ppVal' a <> comma <+> ppTyped ppVal' (const b <$> a)
         ppTupleT a b = parens $ ppTyped ppVal' a <> comma <+> ppTyp' b
         ppVal'       = ppValue' pp
         ppTyp'       = ppTyped ppVal'

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -312,7 +312,7 @@ ppType (PtrTo adr ty)    = ppType ty <+> ppAddrSpace adr <> char '*'
 ppType (PtrOpaque adr)   = "ptr" <+> ppAddrSpace adr
 ppType (Struct ts)       = structBraces (commas (map ppType ts))
 ppType (PackedStruct ts) = angles (structBraces (commas (map ppType ts)))
-ppType (FunTy r as va)   = ppType r <> ppArgList va (map ppType as)
+ppType (FunTy r as va)   = ppType r <+> ppArgList va (map ppType as)
 ppType (Vector len pt)   = angles (integral len <+> char 'x' <+> ppType pt)
 ppType Opaque            = "opaque"
 
@@ -405,7 +405,7 @@ ppDefine d = "define"
          <+> ppMaybe (\gc -> "gc" <+> ppGC gc) (defGC d)
          <+> ppMds (defMetadata d)
          <+> char '{'
-         $+$ vcat (map ppBasicBlock (defBody d))
+         $+$ vcat (punctuate "" $ map ppBasicBlock (defBody d))
          $+$ char '}'
   where
   ppMds mdm =
@@ -1390,7 +1390,7 @@ ppInt64ValMd' canFallBack pp = go
 
 
 commas :: Fmt [Doc]
-commas  = fsep . punctuate comma
+commas  = hsep . punctuate comma
 
 -- | Helpful for all of the optional fields that appear in the
 -- metadata values

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -745,17 +745,15 @@ ppVectorIndex i = ppType (PrimType (Integer 32)) <+> ppValue i
 
 ppAlign :: Fmt (Maybe Align)
 ppAlign Nothing      = empty
-ppAlign (Just align) = comma <+> "align" <+> int align
+ppAlign (Just align) | align == 0 = empty
+                     | otherwise = comma <+> "align" <+> int align
 
 ppAlloca :: Type -> AddrSpace -> Maybe (Typed Value) -> Fmt (Maybe Int)
-ppAlloca ty as mbLen mbAlign = "alloca" <+> ppType ty <> len <> align <> addrspace
+ppAlloca ty as mbLen mbAlign = "alloca" <+> ppType ty <> len <> ppAlign mbAlign <> addrspace
   where
   len = fromMaybe empty $ do
     l <- mbLen
     return (comma <+> ppTyped ppValue l)
-  align = fromMaybe empty $ do
-    a <- mbAlign
-    return (comma <+> "align" <+> int a)
   addrspace = if as /= AddrSpace 0 then comma <+> ppAddrSpace as else empty
 
 ppCall :: Bool -> Type -> Value -> Fmt [Typed Value]

--- a/test/Output.hs
+++ b/test/Output.hs
@@ -34,7 +34,7 @@ tests = Tasty.testGroup "LLVM pretty-printing output tests"
         s1 = Effect
              (GEP True (Alias (Ident "hi")) (Typed Opaque dcu) [])
              []
-        s2 = Effect (Load PtrOpaque (Typed Opaque ValNull) Nothing Nothing)
+        s2 = Effect (Load (PtrOpaque (AddrSpace 0)) (Typed Opaque ValNull) Nothing Nothing)
              [ ("location", ValMdLoc $ DebugLoc { dlLine = 12
                                                 , dlCol = 34
                                                 , dlScope = ValMdRef 5


### PR DESCRIPTION
Address spaces default to 0 and are currently mostly used by CHERI for capabilities (address space 200).

The thread_local property is properly read and reported.

Various formatting changes are implemented to more closely match llvm-dis output.