### PR TITLE
More parameterization for functions not needing a specialized type parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for llvm-pretty
 
+## pending
+
+* Changed some of the signatures of helper functions in the AST to make them more
+  flexible by using `Type' ident` rather than `Type` in their signatures (the
+  latter fixes `ident` to be `Ident`). Changed functions: `isAlias`,
+  `isPrimTypeOf`, `isVector`, `isVectorOf`, `isArray`, and `isPointer`.
+
 ## 0.12.1.0 (August 2024)
 
 * Fix for printing NaN and infinite floating point values.

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -480,11 +480,11 @@ isFloatingPoint :: PrimType -> Bool
 isFloatingPoint (FloatType _) = True
 isFloatingPoint _             = False
 
-isAlias :: Type -> Bool
+isAlias :: Type' ident -> Bool
 isAlias Alias{} = True
 isAlias _       = False
 
-isPrimTypeOf :: (PrimType -> Bool) -> Type -> Bool
+isPrimTypeOf :: (PrimType -> Bool) -> Type' lab -> Bool
 isPrimTypeOf p (PrimType pt) = p pt
 isPrimTypeOf _ _             = False
 
@@ -496,20 +496,20 @@ isInteger :: PrimType -> Bool
 isInteger Integer{} = True
 isInteger _         = False
 
-isVector :: Type -> Bool
+isVector :: Type' lab -> Bool
 isVector Vector{} = True
 isVector _        = False
 
-isVectorOf :: (Type -> Bool) -> Type -> Bool
+isVectorOf :: (Type' lab -> Bool) -> Type' lab -> Bool
 isVectorOf p (Vector _ e) = p e
 isVectorOf _ _            = False
 
-isArray :: Type -> Bool
+isArray :: Type' ident -> Bool
 isArray ty = case ty of
   Array _ _ -> True
   _         -> False
 
-isPointer :: Type -> Bool
+isPointer :: Type' ident -> Bool
 isPointer (PtrTo _) = True
 isPointer PtrOpaque = True
 isPointer _         = False

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -484,7 +484,7 @@ isAlias :: Type' ident -> Bool
 isAlias Alias{} = True
 isAlias _       = False
 
-isPrimTypeOf :: (PrimType -> Bool) -> Type' lab -> Bool
+isPrimTypeOf :: (PrimType -> Bool) -> Type' ident -> Bool
 isPrimTypeOf p (PrimType pt) = p pt
 isPrimTypeOf _ _             = False
 
@@ -496,11 +496,11 @@ isInteger :: PrimType -> Bool
 isInteger Integer{} = True
 isInteger _         = False
 
-isVector :: Type' lab -> Bool
+isVector :: Type' ident -> Bool
 isVector Vector{} = True
 isVector _        = False
 
-isVectorOf :: (Type' lab -> Bool) -> Type' lab -> Bool
+isVectorOf :: (Type' ident -> Bool) -> Type' ident -> Bool
 isVectorOf p (Vector _ e) = p e
 isVectorOf _ _            = False
 


### PR DESCRIPTION
Weakens type declarations to be more permissive where the stricter type isn't needed.  This  should not affect any existing uses, but permits a broader utilization of these functions where desireable.