### PR TITLE
Adapt to metadata-related changes in LLVM 21

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,6 +18,6 @@ jobs:
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1
     with:
       cabal: ${{ matrix.cabal }}
-      cache-key-prefix: v1
+      cache-key-prefix: v2
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
   the same sign. This is used by LLVM 20 and up.
 * Add `dlAtomGroup` and `dlAtomRank` fields to `DebugLoc'`, which were
   introduced in LLVM 21.
+* Add `dilColumn`, `dilIsArtificial`, and `dilCoroSuspendIdx` fields to
+  `DILabel'`, which were introduced in LLVM 21.
 * Fix a bug that would cause `indirectbr` statements to be pretty-printed
   incorrectly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@
   introduced in LLVM 21.
 * Add `dilColumn`, `dilIsArtificial`, and `dilCoroSuspendIdx` fields to
   `DILabel'`, which were introduced in LLVM 21.
+* The following debug-related fields have had their types changed from `Word64`
+  to `Maybe (ValMd' lab)`:
+
+  * `DIBasicType'`: `dibtSize`
+  * `DICompositeType'`: `dictSize` and `dictOffset`
+  * `DIDerivedType'`: `didtSize` and `didtOffset`
+
+  This allows them to encode non-constant sizes and offsets (a capability used
+  by Ada, for instance) in LLVM 21 or later.
 * Fix a bug that would cause `indirectbr` statements to be pretty-printed
   incorrectly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
     unsigned or signed overflow. These are used by LLVM 20 and up.
 * Add a `Bool` field to `ICmp`, which indicates that the arguments must have
   the same sign. This is used by LLVM 20 and up.
+* Add `dlAtomGroup` and `dlAtomRank` fields to `DebugLoc'`, which were
+  introduced in LLVM 21.
 * Fix a bug that would cause `indirectbr` statements to be pretty-printed
   incorrectly.
 

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1774,6 +1774,9 @@ data DILabel' lab = DILabel
     , dilName  :: String
     , dilFile  :: Maybe (ValMd' lab)
     , dilLine  :: Word32
+    , dilColumn :: Word32 -- ^ Introduced in LLVM 21.
+    , dilIsArtificial :: Bool -- ^ Introduced in LLVM 21.
+    , dilCoroSuspendIdx :: Maybe Word32 -- ^ Introduced in LLVM 21.
     } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DIImportedEntity = DIImportedEntity' BlockLabel

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -159,7 +159,7 @@ module Text.LLVM.AST
   , DwarfVirtuality
   , DIFlags
   , DIEmissionKind
-  , DIBasicType(..)
+  , DIBasicType'(..), DIBasicType
   , DICompileUnit'(..), DICompileUnit
   , DICompositeType'(..), DICompositeType
   , DIDerivedType'(..), DIDerivedType
@@ -1741,7 +1741,7 @@ data RangeSpec
 -- DWARF Debug Info ------------------------------------------------------------
 
 data DebugInfo' lab
-  = DebugInfoBasicType DIBasicType
+  = DebugInfoBasicType (DIBasicType' lab)
   | DebugInfoCompileUnit (DICompileUnit' lab)
   | DebugInfoCompositeType (DICompositeType' lab)
   | DebugInfoDerivedType (DIDerivedType' lab)
@@ -1830,15 +1830,22 @@ type DIEmissionKind = Word8
 dwarf_DW_APPLE_ENUM_KIND_invalid :: Word32
 dwarf_DW_APPLE_ENUM_KIND_invalid = complement (0 :: Word32) -- ~ LLVM 19
 
-data DIBasicType = DIBasicType
+data DIBasicType' lab = DIBasicType
   { dibtTag      :: DwarfTag
   , dibtName     :: String
-  , dibtSize     :: Word64
+  , dibtSize     :: Maybe (ValMd' lab)
+    -- ^ If using LLVM 20 or older, this will always be @Just@ an 'ValMdValue',
+    -- where the underlying value is a 64-bit 'ValInteger'. If using LLVM 21 or
+    -- later, this can also be a null reference (i.e., 'Nothing'), a variable
+    -- (i.e., @Just@ a 'DIGlobalVariable' or 'DILocalVariable'), or an
+    -- expression (i.e., @Just@ a 'DIExpression').
   , dibtAlign    :: Word64
   , dibtEncoding :: DwarfAttrEncoding
   , dibtFlags    :: Maybe DIFlags
   , dibtNumExtraInhabitants :: Word64 -- ^ added in LLVM 20.
-  } deriving (Data, Eq, Generic, Ord, Show, Typeable)
+  } deriving (Data, Eq, Functor, Generic, Ord, Show, Typeable)
+
+type DIBasicType = DIBasicType' BlockLabel
 
 data DICompileUnit' lab = DICompileUnit
   { dicuLanguage           :: DwarfLang
@@ -1874,9 +1881,19 @@ data DICompositeType' lab = DICompositeType
   , dictLine           :: Word32
   , dictScope          :: Maybe (ValMd' lab)
   , dictBaseType       :: Maybe (ValMd' lab)
-  , dictSize           :: Word64
+  , dictSize           :: Maybe (ValMd' lab)
+    -- ^ If using LLVM 20 or older, this will always be @Just@ an 'ValMdValue',
+    -- where the underlying value is a 64-bit 'ValInteger'. If using LLVM 21 or
+    -- later, this can also be a null reference (i.e., 'Nothing'), a variable
+    -- (i.e., @Just@ a 'DIGlobalVariable' or 'DILocalVariable'), or an
+    -- expression (i.e., @Just@ a 'DIExpression').
   , dictAlign          :: Word64
-  , dictOffset         :: Word64
+  , dictOffset         :: Maybe (ValMd' lab)
+    -- ^ If using LLVM 20 or older, this will always be @Just@ an 'ValMdValue',
+    -- where the underlying value is a 64-bit 'ValInteger'. If using LLVM 21 or
+    -- later, this can also be a null reference (i.e., 'Nothing'), a variable
+    -- (i.e., @Just@ a 'DIGlobalVariable' or 'DILocalVariable'), or an
+    -- expression (i.e., @Just@ a 'DIExpression').
   , dictFlags          :: DIFlags
   , dictElements       :: Maybe (ValMd' lab)
   , dictRuntimeLang    :: DwarfLang
@@ -1904,9 +1921,19 @@ data DIDerivedType' lab = DIDerivedType
   , didtLine :: Word32
   , didtScope :: Maybe (ValMd' lab)
   , didtBaseType :: Maybe (ValMd' lab)
-  , didtSize :: Word64
+  , didtSize :: Maybe (ValMd' lab)
+    -- ^ If using LLVM 20 or older, this will always be @Just@ an 'ValMdValue',
+    -- where the underlying value is a 64-bit 'ValInteger'. If using LLVM 21 or
+    -- later, this can also be a null reference (i.e., 'Nothing'), a variable
+    -- (i.e., @Just@ a 'DIGlobalVariable' or 'DILocalVariable'), or an
+    -- expression (i.e., @Just@ a 'DIExpression').
   , didtAlign :: Word64
-  , didtOffset :: Word64
+  , didtOffset :: Maybe (ValMd' lab)
+    -- ^ If using LLVM 20 or older, this will always be @Just@ an 'ValMdValue',
+    -- where the underlying value is a 64-bit 'ValInteger'. If using LLVM 21 or
+    -- later, this can also be a null reference (i.e., 'Nothing'), a variable
+    -- (i.e., @Just@ a 'DIGlobalVariable' or 'DILocalVariable'), or an
+    -- expression (i.e., @Just@ a 'DIExpression').
   , didtFlags :: DIFlags
   , didtExtraData :: Maybe (ValMd' lab)
   , didtDwarfAddressSpace :: Maybe Word32

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1584,6 +1584,8 @@ data DebugLoc' lab = DebugLoc
   , dlScope :: ValMd' lab
   , dlIA    :: Maybe (ValMd' lab)
   , dlImplicit :: Bool
+  , dlAtomGroup :: Word64 -- ^ Introduced in LLVM 21
+  , dlAtomRank :: Word64 -- ^ Introduced in LLVM 21
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show, Typeable)
 
 type DebugLoc = DebugLoc' BlockLabel

--- a/src/Text/LLVM/Labels.hs
+++ b/src/Text/LLVM/Labels.hs
@@ -135,6 +135,7 @@ instance HasLabel DbgRecValue'                where relabel = $(generateRelabel 
 instance HasLabel DILabel'                    where relabel = $(generateRelabel 'relabel ''DILabel')
 instance HasLabel DebugLoc'                   where relabel = $(generateRelabel 'relabel ''DebugLoc')
 instance HasLabel DebugInfo'                  where relabel = $(generateRelabel 'relabel ''DebugInfo')
+instance HasLabel DIBasicType'                where relabel = $(generateRelabel 'relabel ''DIBasicType')
 instance HasLabel DIDerivedType'              where relabel = $(generateRelabel 'relabel ''DIDerivedType')
 instance HasLabel DISubroutineType'           where relabel = $(generateRelabel 'relabel ''DISubroutineType')
 instance HasLabel DISubrange'                 where relabel = $(generateRelabel 'relabel ''DISubrange')

--- a/src/Text/LLVM/Lens.hs
+++ b/src/Text/LLVM/Lens.hs
@@ -31,7 +31,7 @@ concat <$> mapM (makeLensesWith (lensRules & lensField .~ (\_ _ n -> [TopName $ 
     , ''DebugInfo'
     , ''DIFile
     , ''DISubrange'
-    , ''DIBasicType
+    , ''DIBasicType'
     , ''DIExpression
     , ''DISubprogram'
     , ''DISubroutineType'

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -925,13 +925,20 @@ ppDebugLoc' pp dl = (if llvmVer >= llvmV3_7 then "!DILocation"
              <> parens (commas [ "line:"   <+> integral (dlLine dl)
                                , "column:" <+> integral (dlCol dl)
                                , "scope:"  <+> ppValMd' pp (dlScope dl)
-                               ] <> mbIA <> mbImplicit)
+                               ] <> mbIA <> mbImplicit <>
+                        when' (llvmVer >= 21) (mbAtomGroup <> mbAtomRank))
 
   where
   mbIA = case dlIA dl of
            Just md -> comma <+> "inlinedAt:" <+> ppValMd' pp md
            Nothing -> empty
   mbImplicit = if dlImplicit dl then comma <+> "implicit" else empty
+  mbAtomGroup = if dlAtomGroup dl > 0
+                  then comma <+> "atomGroup:" <+> integral (dlAtomGroup dl)
+                  else empty
+  mbAtomRank = if dlAtomRank dl > 0
+                 then comma <+> "atomRank:" <+> integral (dlAtomRank dl)
+                 else empty
 
 ppDebugLoc :: Fmt DebugLoc
 ppDebugLoc = ppDebugLoc' ppLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1161,11 +1161,17 @@ ppDIImportedEntity = ppDIImportedEntity' ppLabel
 
 ppDILabel' :: Fmt i -> Fmt (DILabel' i)
 ppDILabel' pp ie = "!DILabel"
-  <> parens (mcommas [ (("scope:"  <+>) . ppValMd' pp) <$> dilScope ie
-                     , pure ("name:" <+> ppStringLiteral (dilName ie))
-                     , (("file:"   <+>) . ppValMd' pp) <$> dilFile ie
-                     , pure ("line:"   <+> integral (dilLine ie))
-                     ])
+  <> parens (mcommas $
+       [ (("scope:"  <+>) . ppValMd' pp) <$> dilScope ie
+       , pure ("name:" <+> ppStringLiteral (dilName ie))
+       , (("file:"   <+>) . ppValMd' pp) <$> dilFile ie
+       , pure ("line:"   <+> integral (dilLine ie))
+       ] ++
+       when' (llvmVer >= 21)
+       [ pure ("column:" <+> integral (dilColumn ie))
+       , pure ("isArtificial:" <+> ppBool (dilIsArtificial ie))
+       , (("coroSuspendIdx:" <+>) . integral) <$> dilCoroSuspendIdx ie
+       ])
 
 ppDILabel :: Fmt DILabel
 ppDILabel = ppDILabel' ppLabel

--- a/test/Metadata.hs
+++ b/test/Metadata.hs
@@ -22,7 +22,9 @@ tests = Tasty.testGroup "LLVM metadata tests" $
                                            , dlCol = 34
                                            , dlScope = ValMdRef 5
                                            , dlIA = Nothing
-                                           , dlImplicit = True })
+                                           , dlImplicit = True
+                                           , dlAtomGroup = 0
+                                           , dlAtomRank = 0 })
              , ("moo", ValMdString @Value "cow")
              ]
   in

--- a/test/Output.hs
+++ b/test/Output.hs
@@ -40,7 +40,9 @@ tests = Tasty.testGroup "LLVM pretty-printing output tests"
                                                 , dlCol = 34
                                                 , dlScope = ValMdRef 5
                                                 , dlIA = Nothing
-                                                , dlImplicit = True })
+                                                , dlImplicit = True
+                                                , dlAtomGroup = 0
+                                                , dlAtomRank = 0 })
              ]
         s3 = Effect
                (IndirectBr


### PR DESCRIPTION
This is a collection of three commits that allow `llvm-pretty` to support metadata found in LLVM 21:

* Add `dlAtom{Group,Rank}` fields to `DebugLoc'` (https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/320)
* Add `dil{Column,IsArtificial,CoroSuspendIdx}` fields to `DILabel'` (https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/326)
* Support non-constant sizes/offsets in `DI{Basic,Derived,Composite}Type` (https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/321)