### PR TITLE
Downgrade the CI to GHC 9.12.2.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,7 +15,9 @@ jobs:
         cabal: ["3.14.2.0"]
         failure-expected: [false]
         include:
-          - ghc: "9.12.2"
+          - os: "ubuntu-24.04"
+            ghc: "9.12.2"
+            cabal: "3.14.2.0"
             failure-expected: true
       fail-fast: false
     continue-on-error: ${{ matrix.failure-expected }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,9 +11,14 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-24.04"]
-        ghc: ["9.8.4", "9.10.1", "9.12.2"]
+        ghc: ["9.8.4", "9.10.1"]
         cabal: ["3.14.2.0"]
+        failure-expected: [false]
+        include:
+          - ghc: "9.12.2"
+            failure-expected: true
       fail-fast: false
+    continue-on-error: ${{ matrix.failure-expected }}
     name: ${{ matrix.os }} - GHC ${{ matrix.ghc }} - Cabal ${{ matrix.cabal }}
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1
     with:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-24.04"]
-        ghc: ["9.8.4", "9.10.1", "9.12.3"]
+        ghc: ["9.8.4", "9.10.1", "9.12.2"]
         cabal: ["3.14.2.0"]
       fail-fast: false
     name: ${{ matrix.os }} - GHC ${{ matrix.ghc }} - Cabal ${{ matrix.cabal }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,7 +15,9 @@ jobs:
         cabal: ["3.14.2.0"]
         test: [true]
         include:
-          - ghc: "9.12.2"
+          - os: "ubuntu-24.04"
+            ghc: "9.12.2"
+            cabal: "3.14.2.0"
             test: false
       fail-fast: false
     name: ${{ matrix.os }} - GHC ${{ matrix.ghc }} - Cabal ${{ matrix.cabal }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,15 +15,13 @@ jobs:
         cabal: ["3.14.2.0"]
         failure-expected: [false]
         include:
-          - os: "ubuntu-24.04"
-            ghc: "9.12.2"
-            cabal: "3.14.2.0"
+          - ghc: "9.12.2"
             failure-expected: true
       fail-fast: false
-    continue-on-error: ${{ matrix.failure-expected }}
     name: ${{ matrix.os }} - GHC ${{ matrix.ghc }} - Cabal ${{ matrix.cabal }}
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1
     with:
+      continue-on-error: ${{ matrix.failure-expected }}
       cabal: ${{ matrix.cabal }}
       cache-key-prefix: v2
       ghc: ${{ matrix.ghc }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,16 +13,16 @@ jobs:
         os: ["ubuntu-24.04"]
         ghc: ["9.8.4", "9.10.1"]
         cabal: ["3.14.2.0"]
-        failure-expected: [false]
+        test: [true]
         include:
           - ghc: "9.12.2"
-            failure-expected: true
+            test: false
       fail-fast: false
     name: ${{ matrix.os }} - GHC ${{ matrix.ghc }} - Cabal ${{ matrix.cabal }}
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1
     with:
-      continue-on-error: ${{ matrix.failure-expected }}
       cabal: ${{ matrix.cabal }}
       cache-key-prefix: v2
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}
+      test: ${{ matrix.test }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,11 +14,13 @@ jobs:
         ghc: ["9.8.4", "9.10.1"]
         cabal: ["3.14.2.0"]
         test: [true]
+        build-targets: ["all"]
         include:
           - os: "ubuntu-24.04"
             ghc: "9.12.2"
             cabal: "3.14.2.0"
             test: false
+            build-targets: "lib:llvm-pretty"
       fail-fast: false
     name: ${{ matrix.os }} - GHC ${{ matrix.ghc }} - Cabal ${{ matrix.cabal }}
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1
@@ -28,3 +30,4 @@ jobs:
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}
       test: ${{ matrix.test }}
+      build-targets: ${{ matrix.build-targets }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,6 +20,8 @@ jobs:
             ghc: "9.12.2"
             cabal: "3.14.2.0"
             test: false
+            # Building the test suite fails on GHC 9.12.2 due to a compiler bug;
+            # see https://gitlab.haskell.org/ghc/ghc/-/issues/25771
             build-targets: "lib:llvm-pretty"
       fail-fast: false
     name: ${{ matrix.os }} - GHC ${{ matrix.ghc }} - Cabal ${{ matrix.cabal }}

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -13,7 +13,7 @@ Description:
   Augustsson.  The library provides a monadic interface to a pretty printer,
   that allows functions to be defined and called, generating the corresponding
   LLVM assembly when run.
-tested-with:         GHC==9.12.3, GHC==9.10.1, GHC==9.8.4
+tested-with:         GHC==9.12.2, GHC==9.10.1, GHC==9.8.4
 extra-doc-files:     CHANGELOG.md, README.md
 
 


### PR DESCRIPTION
`ghcup` has pulled GHC 9.12.3 due to [a critical bug](https://discourse.haskell.org/t/critical-code-generation-bug-with-ghc-9-12-3/13505), breaking the CI in this repository. This pull request restores the use of GHC 9.12.2.