### PR TITLE
Fix how single-precision floats get printed in hex

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -28,7 +28,7 @@ jobs:
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v2
     with:
       cabal: ${{ matrix.cabal }}
-      cache-key-prefix: v3a
+      cache-key-prefix: v3b
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}
       test: ${{ matrix.test }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+* Corrected the printing of non-normal single-precision floating point
+  constants.
+
 * Added missing `FloatType` case `BFloat` for 16-bit "Brain" floats.
 
 * Added missing `Value'` cases for floating point types:

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -28,7 +28,7 @@ import Data.Char (isAlphaNum,isAscii,isDigit,isPrint,ord,toUpper)
 import Data.List ( intersperse, nub )
 import qualified Data.Map as Map
 import Data.Maybe (catMaybes,fromMaybe,isJust)
-import GHC.Float (castDoubleToWord64, castFloatToWord32, castWord32ToFloat, float2Double)
+import GHC.Float (castDoubleToWord64, castWord32ToFloat, float2Double)
 import Numeric (showHex)
 import Text.PrettyPrint.HughesPJ
 import Data.Int

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -28,7 +28,7 @@ import Data.Char (isAlphaNum,isAscii,isDigit,isPrint,ord,toUpper)
 import Data.List ( intersperse, nub )
 import qualified Data.Map as Map
 import Data.Maybe (catMaybes,fromMaybe,isJust)
-import GHC.Float (castDoubleToWord64, castFloatToWord32, castWord32ToFloat)
+import GHC.Float (castDoubleToWord64, castFloatToWord32, castWord32ToFloat, float2Double)
 import Numeric (showHex)
 import Text.PrettyPrint.HughesPJ
 import Data.Int
@@ -943,7 +943,7 @@ ppValue' pp val = case val of
       else float $ castWord32ToFloat $ bfloatToSingleBits x
   ValFloat f         ->
     if isInfinite f || isNaN f
-      then text "0x" <> text (showHex (castFloatToWord32 f) "")
+      then text "0x" <> text (showHex (castDoubleToWord64 $ float2Double f) "")
       else float f
   ValDouble d        ->
     if isInfinite d || isNaN d

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -943,10 +943,14 @@ ppValue' pp val = case val of
       else float $ castWord32ToFloat $ bfloatToSingleBits x
   ValFloat f         ->
     if isInfinite f || isNaN f
+      -- shown as 0x<<16-hex-digits>>, per
+      -- https://llvm.org/docs/LangRef.html#simple-constants
       then text "0x" <> text (showHex (castDoubleToWord64 $ float2Double f) "")
       else float f
   ValDouble d        ->
     if isInfinite d || isNaN d
+      -- shown as 0x<<16-hex-digits>>, per
+      -- https://llvm.org/docs/LangRef.html#simple-constants
       then text "0x" <> text (showHex (castDoubleToWord64 d) "")
       else double d
   ValFP80 (FP80_LongDouble e s) ->

--- a/test/Output.hs
+++ b/test/Output.hs
@@ -372,22 +372,22 @@ tests = Tasty.testGroup "LLVM pretty-printing output tests"
   , testCase "Positive Infinity (float)" $
     assertEqLines
       (ppToText $ ppLLVM37 ppValue (ValFloat (castWord32ToFloat 0x7F800000)))
-      "0x7f800000"
+      "0x7ff0000000000000"
 
   , testCase "Negative Infinity (float)" $
     assertEqLines
       (ppToText $ ppLLVM37 ppValue (ValFloat (castWord32ToFloat 0xFF800000)))
-      "0xff800000"
+      "0xfff0000000000000"
 
   , testCase "NaN 1 (float)" $
     assertEqLines
       (ppToText $ ppLLVM37 ppValue (ValFloat (castWord32ToFloat 0x7FC00000)))
-      "0x7fc00000"
+      "0x7ff8000000000000"
 
   , testCase "NaN 2 (float)" $
     assertEqLines
       (ppToText $ ppLLVM37 ppValue (ValFloat (castWord32ToFloat 0x7FD00000)))
-      "0x7fd00000"
+      "0x7ffa000000000000"
 
   , testCase "Positive Infinity (double)" $
     assertEqLines


### PR DESCRIPTION
They're supposed to be promoted to double and then printed as 64-bit integers.

Closes #187.