### PR TITLE
Support metadata fields added in LLVM 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support LLVM 22:
   * `DICompileUnit'` now has an additional `dicuSourceLanguageVersion :: Word64`
     field.
+  * `DIBasicType'` now has an additional `dibtDataSize :: Word32` field.
 
 * Corrected the printing of non-normal single-precision floating point
   constants.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next
 
+* Support LLVM 22:
+  * `DICompileUnit'` now has an additional `dicuSourceLanguageVersion :: Word64`
+    field.
+
 * Corrected the printing of non-normal single-precision floating point
   constants.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ assembly when run.
 
 ## LLVM language feature support
 
+<!--
+If you update the latest LLVM version mentioned below, make sure to also update
+the definition of `llvmVlatest` in `Text.LLVM.PP`.
+-->
+
 Currently, `llvm-pretty` supports LLVM versions up through 22. As a result of
 the broad version coverage, the `llvm-pretty` AST is a superset of all versions
 of the LLVM AST. This means that the manner in which certain information is

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ assembly when run.
 
 ## LLVM language feature support
 
-Currently, `llvm-pretty` supports LLVM versions up through 17. As a result of
+Currently, `llvm-pretty` supports LLVM versions up through 22. As a result of
 the broad version coverage, the `llvm-pretty` AST is a superset of all versions
 of the LLVM AST. This means that the manner in which certain information is
 presented in the `llvm-pretty` AST (e.g., during pretty printing) will be

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1882,6 +1882,7 @@ data DIBasicType' lab = DIBasicType
   , dibtEncoding :: DwarfAttrEncoding
   , dibtFlags    :: Maybe DIFlags
   , dibtNumExtraInhabitants :: Word64 -- ^ added in LLVM 20.
+  , dibtDataSize :: Word32 -- ^ added in LLVM 22.
   } deriving (Data, Eq, Functor, Generic, Ord, Show)
 
 type DIBasicType = DIBasicType' BlockLabel

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1909,6 +1909,8 @@ data DICompileUnit' lab = DICompileUnit
   , dicuRangesBaseAddress  :: Bool
   , dicuSysRoot            :: Maybe String
   , dicuSDK                :: Maybe String
+  , dicuSourceLanguageVersion :: Word32
+    -- ^ added in LLVM 22
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show)
 
 type DICompileUnit = DICompileUnit' BlockLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1342,6 +1342,12 @@ ppDICompileUnit' pp cu = "!DICompileUnit"
        ,     (("sdk:"                   <+>) . doubleQuotes . text)
              <$> (dicuSDK cu)
        ]
+       ++
+       when' (llvmVer >= 22)
+       [ if dicuSourceLanguageVersion cu > 0
+         then pure ("sourceLanguageVersion:" <+> integral (dicuSourceLanguageVersion cu))
+         else Nothing
+       ]
        )
 
 

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1297,7 +1297,7 @@ ppDITemplateValueParameter = ppDITemplateValueParameter' ppLabel
 
 ppDIBasicType' :: Fmt i -> Fmt (DIBasicType' i)
 ppDIBasicType' pp bt = "!DIBasicType"
-  <> parens (mcommas
+  <> parens (mcommas $
        [ pure ("tag:"      <+> integral (dibtTag bt))
        , pure ("name:"     <+> doubleQuotes (text (dibtName bt)))
        ,     (("size:"     <+>) . ppSizeOrOffsetValMd' pp) <$> dibtSize bt
@@ -1308,7 +1308,14 @@ ppDIBasicType' pp bt = "!DIBasicType"
        , if dibtNumExtraInhabitants bt > 0
          then pure ("numExtraInhabitants:" <+> integral (dibtNumExtraInhabitants bt))
          else Nothing
-       ])
+       ]
+       ++
+       when' (llvmVer >= 22)
+       [ if dibtDataSize bt > 0
+         then pure ("dataSize:" <+> integral (dibtDataSize bt))
+         else Nothing
+       ]
+       )
 
 ppDICompileUnit' :: Fmt i -> Fmt (DICompileUnit' i)
 ppDICompileUnit' pp cu = "!DICompileUnit"

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -75,8 +75,8 @@ llvmV3_8 = 3
 -- this is used for defaulting and otherwise reporting the maximum LLVM version
 -- known to be supported.
 llvmVlatest :: LLVMVer
-llvmVlatest = 22
-
+llvmVlatest = 22 -- If you update this, make sure to also update the latest LLVM
+                 -- version mentioned in the README.
 
 -- | The differences between various versions of the llvm textual AST.
 newtype Config = Config { cfgVer :: LLVMVer }

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -75,7 +75,7 @@ llvmV3_8 = 3
 -- this is used for defaulting and otherwise reporting the maximum LLVM version
 -- known to be supported.
 llvmVlatest :: LLVMVer
-llvmVlatest = 19
+llvmVlatest = 22
 
 
 -- | The differences between various versions of the llvm textual AST.

--- a/test/Output.hs
+++ b/test/Output.hs
@@ -74,6 +74,7 @@ tests = Tasty.testGroup "LLVM pretty-printing output tests"
                               , dicuRangesBaseAddress = True
                               , dicuSysRoot = Just "the root"
                               , dicuSDK = Just "SDK"
+                              , dicuSourceLanguageVersion = 0
                               }
         dtt = ValMdDebugInfo
               $ DebugInfoTemplateTypeParameter


### PR DESCRIPTION
This adds `dicuSourceLanguageVersion :: Word64` to `DICompileUnit'` and `dibtDataSize :: Word32` to `DIBasicType'` to reflect similar changes in LLVM 22. Together, these pave the way for LLVM 22 bitcode parsing support in `llvm-pretty-bc-parser` (see https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/339 and https://github.com/GaloisInc/llvm-pretty-bc-parser/issues/340, respectively).