### PR TITLE
Add atFileLines to DebugUtils and use in PP for new ppModuleAtLines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@
   * `ValFP128_PPC` containing an `FP128_PPCValue`
     (a wrapper around two `Double`s)
 
+* Added the `atFileLines` function to `DebugUtils.hs` which retrieves the
+  statements associated with a specific source file and line number for user
+  processing.
+
+* Added the `ppModuleAtLine` which can be used to pretty-print only the portion
+  of the bitcode that is associated with a specific source file and line number
+  (this uses the new `atFileLines` function internally).
+
 ## 0.14.0.0 -- 2026-01-23
 
 * Changes to support LLVM 19 (some of these changes are not backward-compatible):

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -56,6 +56,7 @@ Library
                        microlens        >= 0.4,
                        microlens-th     >= 0.4,
                        microlens-platform >= 0.4,
+                       -- microlens-platform provides the IxValue instance for IntMap
                        syb              >= 0.7,
                        template-haskell >= 2.7,
                        th-abstraction   >= 0.3.1 && <0.8

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -49,11 +49,13 @@ Library
 
   Build-depends:       base             >= 4.11 && < 5,
                        containers       >= 0.4,
+                       filepath         >= 1.4,
                        parsec           >= 3,
                        pretty           >= 1.0.1,
                        monadLib         >= 3.6.1,
                        microlens        >= 0.4,
                        microlens-th     >= 0.4,
+                       microlens-platform >= 0.4,
                        syb              >= 0.7,
                        template-haskell >= 2.7,
                        th-abstraction   >= 0.3.1 && <0.8

--- a/src/Text/LLVM/DebugUtils.hs
+++ b/src/Text/LLVM/DebugUtils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# Language TransformListComp, MonadComprehensions #-}
 {- |
 Module           : Text.LLVM.DebugUtils
@@ -32,18 +34,25 @@ module Text.LLVM.DebugUtils
   -- * Line numbers of definitions
   , debugInfoGlobalLines
   , debugInfoDefineLines
+  , atFileLines
+  , AtFileLines(atDefine, atBlockStart, atStmt, atGlobal)
+  , DefineRel(..)
+  , BlockRel(..)
   ) where
 
 import           Control.Applicative    ((<|>))
 import           Control.Monad          ((<=<))
 import           Data.Bits              (Bits(..))
+import           Data.Bool              (bool)
 import           Data.IntMap            (IntMap)
 import qualified Data.IntMap as IntMap
 import           Data.List              (elemIndex, tails, stripPrefix)
 import           Data.Map               (Map)
 import qualified Data.Map    as Map
-import           Data.Maybe             (fromMaybe, listToMaybe, maybeToList, mapMaybe)
+import           Data.Maybe (fromMaybe, listToMaybe, maybeToList, mapMaybe)
 import           Data.Word              (Word16, Word64)
+import           Lens.Micro.Platform    ((^.), at, _Just, to)
+import           System.FilePath        ( (</>), equalFilePath, normalise )
 import           Text.LLVM.AST
 
 dbgKind :: String
@@ -170,6 +179,31 @@ getDebugInfo :: MdMap -> ValMd -> Maybe DebugInfo
 getDebugInfo mdMap (ValMdRef i)    = getDebugInfo mdMap =<< IntMap.lookup i mdMap
 getDebugInfo _ (ValMdDebugInfo di) = Just di
 getDebugInfo _ _                   = Nothing
+
+getMDFile :: MdMap -> ValMd -> Maybe FilePath
+getMDFile mdMap = \case
+  ValMdLoc l -> getMDFile mdMap $ dlScope l
+  ValMdRef i -> mdMap ^. at i . _Just . to (getMDFile mdMap)
+  ValMdDebugInfo (DebugInfoGlobalVariable gv) ->
+    (getMDFile mdMap =<< digvFile gv) <|> (getMDFile mdMap =<< digvScope gv)
+  ValMdDebugInfo (DebugInfoLocalVariable lv) ->
+    (getMDFile mdMap =<< dilvFile lv) <|> (getMDFile mdMap =<< dilvScope lv)
+  ValMdDebugInfo (DebugInfoSubprogram sp) ->
+    (getMDFile mdMap =<< dispFile sp) <|> (getMDFile mdMap =<< dispScope sp)
+  ValMdDebugInfo (DebugInfoLexicalBlock lb) ->
+    (getMDFile mdMap =<< dilbFile lb) <|> (getMDFile mdMap =<< dilbScope lb)
+  ValMdDebugInfo (DebugInfoLexicalBlockFile lf) ->
+    (getMDFile mdMap =<< dilbfFile lf) <|> (getMDFile mdMap $ dilbfScope lf)
+  ValMdDebugInfo (DebugInfoDerivedType dt) ->
+    (getMDFile mdMap =<< didtFile dt) <|> (getMDFile mdMap =<< didtScope dt)
+  ValMdDebugInfo (DebugInfoCompositeType ct) ->
+    (getMDFile mdMap =<< dictFile ct) <|> (getMDFile mdMap =<< dictScope ct)
+  ValMdDebugInfo (DebugInfoCompileUnit cu) -> getMDFile mdMap =<< dicuFile cu
+  ValMdDebugInfo (DebugInfoNameSpace ns) -> getMDFile mdMap $ dinsFile ns
+  ValMdDebugInfo (DebugInfoLabel bl) ->
+    (getMDFile mdMap =<< dilFile bl) <|> (getMDFile mdMap =<< dilScope bl)
+  ValMdDebugInfo (DebugInfoFile i) -> pure $ difDirectory i </> difFilename i
+  _ -> Nothing
 
 getInteger :: MdMap -> ValMd -> Maybe Integer
 getInteger mdMap (ValMdRef i)                          = getInteger mdMap =<< IntMap.lookup i mdMap
@@ -514,3 +548,96 @@ debugInfoDefineLines = Map.fromList . mapMaybe go . modUnnamedMd
            )
          }) = Just (n, (fromIntegral l))
     go _ = Nothing
+
+
+-- | Given a file and line number and a handler, call the appropriate handler
+-- method on every Define, Block, and Stmt that is associated with the line
+-- number.
+atFileLines :: AtFileLines a b
+            => b -> a -> FilePath -> Integer -> Module -> a
+atFileLines handle seed file line mdule =
+  let mdMap = mkMdMap mdule
+      matchesFile x =
+        let fn = normalise file
+            fl = length fn
+            xl = length x
+            (p,r) = splitAt (xl - fl) x
+        in and [ fl <= xl
+               , fn `equalFilePath` r
+               , null p || "/" == (take 1 $ reverse p)
+               ]
+      locMatch di =
+        let getMDLine = \case
+              ValMdLoc x@(DebugLoc {}) -> dlLine x
+              ValMdDebugInfo (DebugInfoSubprogram x) -> dispLine x
+              ValMdDebugInfo (DebugInfoLocalVariable x) -> dilvLine x
+              ValMdDebugInfo (DebugInfoLexicalBlock x) -> dilbLine x
+              ValMdDebugInfo (DebugInfoGlobalVariable x) -> digvLine x
+              ValMdDebugInfo (DebugInfoDerivedType x) -> didtLine x
+              ValMdDebugInfo (DebugInfoCompositeType x) -> dictLine x
+              ValMdDebugInfo (DebugInfoNameSpace x) -> dinsLine x
+              ValMdDebugInfo (DebugInfoLabel x) -> dilLine x
+              ValMdRef i -> maybe 0 getMDLine $ mdMap ^. at i
+              _ -> 0
+        in and [ maybe False matchesFile (getMDFile mdMap di)
+               , line == (toInteger $ getMDLine di)
+               ]
+      onGlobal a g =
+        bool a (atGlobal handle g a) $ any locMatch $ Map.elems $ globalMetadata g
+      onDefs a d =
+        let isMatch = any locMatch $ Map.elems $ defMetadata d
+            onDecl = bool id (atDefine handle d) isMatch
+        in snd $ foldl onBlock (FirstBlock isMatch, onDecl a) $ defBody d
+      onBlock (dr, a) bb =
+        let onBlockLabel = case bbStmts bb of
+                             [] -> id
+                             (s:_) -> bool id (atBlockStart handle dr bb)
+                                      $ any (locMatch . snd) $ stmtMetadata s
+            sseed = (dr, FirstBlockStmt, onBlockLabel a)
+            (_, _, blkstmts) = foldl onStmt sseed $ bbStmts bb
+        in (OtherBlock, blkstmts)
+      onStmt (dr, br, a) s =
+        bool
+        (dr, FirstLineStmt, a)
+        (dr, ContiguousStmt, atStmt handle dr br s a)
+        $ or [ any (locMatch . snd) $ stmtMetadata s
+             -- n.b. the DebugRecords describe associated data, but do not
+             -- (at this time, circa LLVM 22) contain instruction location
+             -- references, so they are not considered here.
+             , dr == FirstBlock True && null (stmtMetadata s)
+             ]
+  in foldl onGlobal (foldl onDefs seed $ modDefines mdule) $ modGlobals mdule
+
+-- | The handler passed to 'atFileLines' must be an instance of this class.
+--
+-- Here, @b@ is an object for which the following methods can be called with an
+-- accumulator @a@ and the corresponding LLVM AST element that has the @lab@
+-- label type.  The method will return an updated accumulator.
+class AtFileLines a b where
+  -- | The 'atDefine' method is called (before any enclosed 'BasicBlock' or
+  --   'Stmt' elements) if the file and line number are associated with the
+  --   'Define' signature line.
+  atDefine :: b -> Define -> a -> a
+  -- | The 'atBlockStart' method is called if the first 'Stmt' in the
+  --   'BasicBlock' is associated with the file and line number, and before any
+  --   'Stmt's in the block are passed to 'atStmt'.
+  --   the first block in the 'Define'.
+  atBlockStart :: b -> DefineRel -> BasicBlock -> a -> a
+  -- | The 'atStmt' method is called for every 'Stmt' in the basic block that is
+  --   associated with the file and line number.  The boolean value passed is
+  --   true if the 'Stmt' immediately follows a previous 'Stmt' that was
+  --   associated with the same line, or if this was the first 'Stmt' in the
+  --   block.
+  atStmt :: b -> DefineRel -> BlockRel -> Stmt -> a -> a
+  -- | The 'atGlobal' method is called for evey 'Global' that is associated with
+  -- the file and line number.
+  atGlobal :: b -> Global -> a -> a
+
+data DefineRel = FirstBlock Bool -- ^ first block of a 'Define', matched file & line?
+               | OtherBlock      -- ^ other blocks of a 'Define'
+  deriving Eq
+
+data BlockRel = FirstBlockStmt -- ^ first statement in a 'BasicBlock'
+              | ContiguousStmt -- ^ previous statement also matched the file & line
+              | FirstLineStmt  -- ^ previous statement did not match the file & line
+  deriving Eq

--- a/src/Text/LLVM/DebugUtils.hs
+++ b/src/Text/LLVM/DebugUtils.hs
@@ -49,7 +49,7 @@ import qualified Data.IntMap as IntMap
 import           Data.List              (elemIndex, tails, stripPrefix)
 import           Data.Map               (Map)
 import qualified Data.Map    as Map
-import           Data.Maybe (fromMaybe, listToMaybe, maybeToList, mapMaybe)
+import           Data.Maybe             (fromMaybe, listToMaybe, maybeToList, mapMaybe)
 import           Data.Word              (Word16, Word64)
 import           Lens.Micro.Platform    ((^.), at, _Just, to)
 import           System.FilePath        ( (</>), equalFilePath, normalise )
@@ -182,6 +182,8 @@ getDebugInfo _ _                   = Nothing
 
 getMDFile :: MdMap -> ValMd -> Maybe FilePath
 getMDFile mdMap = \case
+  ValMdDebugInfo (DebugInfoFile i) -> pure $ difDirectory i </> difFilename i
+  --  ^^ found it! ^^ or else vvv keep looking (recursively) vvv
   ValMdLoc l -> getMDFile mdMap $ dlScope l
   ValMdRef i -> mdMap ^. at i . _Just . to (getMDFile mdMap)
   ValMdDebugInfo (DebugInfoGlobalVariable gv) ->
@@ -202,7 +204,6 @@ getMDFile mdMap = \case
   ValMdDebugInfo (DebugInfoNameSpace ns) -> getMDFile mdMap $ dinsFile ns
   ValMdDebugInfo (DebugInfoLabel bl) ->
     (getMDFile mdMap =<< dilFile bl) <|> (getMDFile mdMap =<< dilScope bl)
-  ValMdDebugInfo (DebugInfoFile i) -> pure $ difDirectory i </> difFilename i
   _ -> Nothing
 
 getInteger :: MdMap -> ValMd -> Maybe Integer
@@ -564,7 +565,7 @@ atFileLines handle seed file line mdule =
             (p,r) = splitAt (xl - fl) x
         in and [ fl <= xl
                , fn `equalFilePath` r
-               , null p || "/" == (take 1 $ reverse p)
+               , null p || "/" == take 1 (reverse p)
                ]
       locMatch di =
         let getMDLine = \case

--- a/src/Text/LLVM/DebugUtils.hs
+++ b/src/Text/LLVM/DebugUtils.hs
@@ -52,7 +52,8 @@ import qualified Data.Map    as Map
 import           Data.Maybe             (fromMaybe, listToMaybe, maybeToList, mapMaybe)
 import           Data.Word              (Word16, Word64)
 import           Lens.Micro.Platform    ((^.), at, _Just, to)
-import           System.FilePath        ( (</>), equalFilePath, normalise )
+import           System.FilePath        ( (</>), equalFilePath, normalise
+                                        , hasTrailingPathSeparator )
 import           Text.LLVM.AST
 
 dbgKind :: String
@@ -565,7 +566,7 @@ atFileLines handle seed file line mdule =
             (p,r) = splitAt (xl - fl) x
         in and [ fl <= xl
                , fn `equalFilePath` r
-               , null p || "/" == take 1 (reverse p)
+               , null p || hasTrailingPathSeparator p
                ]
       locMatch di =
         let getMDLine = \case

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1736,7 +1736,7 @@ ppDIArgList = ppDIArgList' ppLabel
 -- -------------------------------------------------------------------
 -- Auxiliary pretty-printing functions
 --
--- These are alternative pretty-printing functions (intead of the pretty-printers
+-- These are alternative pretty-printing functions (instead of the pretty-printers
 -- for the basic AST elements above). These functions can be used in
 -- situations where additional or alternative pretty-printing functionality is
 -- needed.
@@ -1747,7 +1747,7 @@ ppDIArgList = ppDIArgList' ppLabel
 -- definition/function).  A range of lines can be displayed by iterative calls
 -- over multiple lines.
 --
--- > putStrLn$ ppLLVM llvmVlatest $ ppModuleAtLine "foo.c" 23 llvmModule
+-- > putStrLn $ ppLLVM llvmVlatest $ ppModuleAtLine "foo.c" 23 llvmModule
 --
 -- The above example shows all the lines in llvmModule that correspond to line 23
 -- of the "foo.c" source file.
@@ -1764,8 +1764,8 @@ data DocBld = Start Doc -- ^ at the start: doc-so-far
               -- ^ atDefine: doc-so-far, the define, and the doc for the body of
               -- the AtFileLines
             | BS DocBld (Maybe BlockLabel) Doc
-            -- ^ atBlockStart: doc-so-far, block label (if any), and doc for the
-            -- block body
+              -- ^ atBlockStart: doc-so-far, block label (if any), and doc for the
+              -- block body
 
 instance AtFileLines DocBld AddDocAtLine where
   atDefine _ d docbld = DF docbld d empty

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -19,7 +19,7 @@
 --
 module Text.LLVM.PP
   (
-    Config(cfgVer), withConfig
+    Config(Config, cfgVer), withConfig
   , LLVMVer, llvmVer, llvmVerToString
   , llvmVlatest, llvmV3_5, llvmV3_6, llvmV3_7, llvmV3_8
   , ppLLVM, ppLLVM35, ppLLVM36, ppLLVM37, ppLLVM38

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1596,13 +1596,31 @@ ppDIArgList = ppDIArgList' ppLabel
 -- situations where additional or alternative pretty-printing functionality is
 -- needed.
 
-ppModuleAtLines :: (?config :: Config) => String -> Integer -> Fmt Module
-ppModuleAtLines file line =
+-- | This is an auxiliary pretty printer for showing just part of a module: the
+-- part corresponding to a specific source file and line in the source file
+-- (whereas ppModule or even ppDefine will show the *entire* module or
+-- definition/function).  A range of lines can be displayed by iterative calls
+-- over multiple lines.
+--
+-- > putStrLn$ ppLLVM llvmVlatest $ ppModuleAtLine "foo.c" 23 llvmModule
+--
+-- The above example shows all the lines in llvmModule that correspond to line 23
+-- of the "foo.c" source file.
+ppModuleAtLine :: (?config :: Config) => String -> Integer -> Fmt Module
+ppModuleAtLine file line =
   toDoc . atFileLines (AddDocAtLine ?config) (Start empty) file line
 
+-- internal helper for the AtFileLines instance below
 data AddDocAtLine = AddDocAtLine Config
 
-data DocBld = Start Doc | DF DocBld Define Doc | BS DocBld (Maybe BlockLabel) Doc
+-- internal helper for the AtFileLines instance below
+data DocBld = Start Doc -- ^ at the start: doc-so-far
+            | DF DocBld Define Doc
+              -- ^ atDefine: doc-so-far, the define, and the doc for the body of
+              -- the AtFileLines
+            | BS DocBld (Maybe BlockLabel) Doc
+            -- ^ atBlockStart: doc-so-far, block label (if any), and doc for the
+            -- block body
 
 instance AtFileLines DocBld AddDocAtLine where
   atDefine _ d docbld = DF docbld d empty
@@ -1615,12 +1633,14 @@ instance AtFileLines DocBld AddDocAtLine where
     in withConfig c $ emit $ bool (text "..." $$) (empty $$) isContig $ ppStmt s
   atGlobal (AddDocAtLine c) g = withConfig c $ emit $ ppGlobal g
 
+-- internal helper for the AtFileLines instance below
 emit :: Doc -> DocBld -> DocBld
 emit n = \case
   DF b s d -> DF b s (d $$ n)
   BS b l d -> BS b l (d $$ n)
   Start d -> Start (d $$ n)
 
+-- internal helper for the AtFileLines instance below
 toDoc :: Fmt DocBld
 toDoc = \case
   DF b s d -> toDoc b $$ ppDefineSig s $$ nest 2 d

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -17,7 +17,152 @@
 --
 -- This is the pretty-printer for llvm assembly versions 3.6 and lower.
 --
-module Text.LLVM.PP where
+module Text.LLVM.PP
+  (
+    Config(cfgVer)
+  , LLVMVer, llvmVer, llvmVerToString
+  , llvmVlatest, llvmV3_5, llvmV3_6, llvmV3_7, llvmV3_8
+  , ppLLVM, ppLLVM35, ppLLVM36, ppLLVM37, ppLLVM38
+  , LLVMPretty(llvmPP)
+  , ppModule
+  , ppSourceName
+  , ppNamedMd
+  , ppUnnamedMd
+  , ppGlobalAlias
+  , ppTargetTriple
+  , ppDataLayout
+  , ppLayoutSpec
+  , ppPointerSize
+  , ppStorage
+  , ppAlignment
+  , ppFunctionPointerAlignType
+  , ppMangling
+  , ppInlineAsm
+  , ppIdent
+  , ppSymbol
+  , ppPrimType
+  , ppFloatType
+  , ppType
+  , ppTypeDecl
+  , ppGlobal
+  , ppGlobalMetadata
+  , ppGlobalAttrs
+  , ppDeclare
+  , ppComdatName
+  , ppComdat
+  , ppSelectionKind
+  , ppDefineSig
+  , ppDefine
+  , ppFunAttr
+  , ppLabelDef
+  , ppLabel
+  , ppBasicBlock
+  , ppStmt
+  , ppAttachedMetadata
+  , ppLinkage
+  , ppVisibility
+  , ppGC
+  , ppTyped
+  , ppSignBits
+  , ppExact
+  , ppArithOp
+  , ppUnaryArithOp
+  , ppBitOp
+  , ppConvOp
+  , ppAtomicOrdering
+  , ppAtomicOp
+  , ppScope
+  , ppInstr
+  , ppLoad
+  , ppStore
+  , ppClauses
+  , ppClause
+  , ppTypedLabel
+  , ppSwitchEntry
+  , ppVectorIndex
+  , ppAlign
+  , ppAlloca
+  , ppCall
+  , ppCallBr
+  , ppCallSym
+  , ppGEP
+  , ppInvoke
+  , ppPhiArg
+  , ppICmpOp
+  , ppFCmpOp
+  , ppValue'
+  , ppValue
+  , ppValMd'
+  , ppValMd
+  , ppDebugLoc'
+  , ppDebugLoc
+  , ppTypedValMd
+  , ppMetadata
+  , ppMetadataNode'
+  , ppMetadataNode
+  , ppStringLiteral
+  , ppAsm
+  , ppConstExpr'
+  , ppConstExpr
+  , ppGepFlags
+  , ppDebugInfo'
+  , ppDebugRecords
+  , ppDebugRecord'
+  , ppDbgRecValue'
+  , ppDbgRecDeclare'
+  , ppDbgRecAssign'
+  , ppDbgRecValueSimple'
+  , ppDebugInfo
+  , ppDIImportedEntity'
+  , ppDIImportedEntity
+  , ppDILabel'
+  , ppDILabel
+  , ppDINameSpace'
+  , ppDINameSpace
+  , ppDITemplateTypeParameter'
+  , ppDITemplateTypeParameter
+  , ppDITemplateValueParameter'
+  , ppDITemplateValueParameter
+  , ppDIBasicType'
+  , ppDICompileUnit'
+  , ppDICompileUnit
+  , ppFlags
+  , ppDICompositeType'
+  , ppDICompositeType
+  , ppDIDerivedType'
+  , ppDIDerivedType
+  , ppDIEnumerator
+  , ppDIExpression
+  , ppDIFile
+  , ppDIGlobalVariable'
+  , ppDIGlobalVariable
+  , ppDIGlobalVariableExpression'
+  , ppDIGlobalVariableExpression
+  , ppDILexicalBlock'
+  , ppDILexicalBlock
+  , ppDILexicalBlockFile'
+  , ppDILexicalBlockFile
+  , ppDILocalVariable'
+  , ppDILocalVariable
+  , ppDISubprogram'
+  , ppDISubprogram
+  , ppDISubrange'
+  , ppDISubrange
+  , ppDISubroutineType'
+  , ppDISubroutineType
+  , ppDIArgList'
+  , ppDIArgList
+  , ppModuleAtLine
+  , ppArgList
+  , ppBool
+  , ppInt64ValMd'
+  , ppSizeOrOffsetValMd'
+  , ppMaybe
+  , hex
+  , onlyOnLLVM
+  , droppedInLLVM
+  )
+where
 
 import Text.LLVM.AST
 import Text.LLVM.DebugUtils

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -19,7 +19,7 @@
 --
 module Text.LLVM.PP
   (
-    Config(cfgVer)
+    Config(cfgVer), withConfig
   , LLVMVer, llvmVer, llvmVerToString
   , llvmVlatest, llvmV3_5, llvmV3_6, llvmV3_7, llvmV3_8
   , ppLLVM, ppLLVM35, ppLLVM36, ppLLVM37, ppLLVM38

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE TypeApplications #-}
@@ -19,11 +20,13 @@
 module Text.LLVM.PP where
 
 import Text.LLVM.AST
+import Text.LLVM.DebugUtils
 import Text.LLVM.Triple.AST (TargetTriple)
 import Text.LLVM.Triple.Print (printTriple)
 
 import Control.Applicative ((<|>))
 import Data.Bits ( shiftL, shiftR, (.|.), (.&.) )
+import Data.Bool ( bool )
 import Data.Char (isAlphaNum,isAscii,isDigit,isPrint,ord,toUpper)
 import Data.List ( intersperse, nub )
 import qualified Data.Map as Map
@@ -407,25 +410,28 @@ ppSelectionKind k =
       ComdatNoDuplicates    -> "noduplicates"
       ComdatSameSize        -> "samesize"
 
-ppDefine :: Fmt Define
-ppDefine d = "define"
-         <+> ppMaybe ppLinkage (defLinkage d)
-         <+> ppMaybe ppVisibility (defVisibility d)
-         <+> ppType (defRetType d)
-         <+> ppSymbol (defName d)
-          <> ppArgList (defVarArgs d) (map (ppTyped ppIdent) (defArgs d))
-         <+> hsep (ppFunAttr <$> defAttrs d)
-         <+> ppMaybe (\s  -> "section" <+> doubleQuotes (text s)) (defSection d)
-         <+> ppMaybe (\gc -> "gc" <+> ppGC gc) (defGC d)
-         <+> ppMds (defMetadata d)
-         <+> char '{'
-         $+$ vcat (map ppBasicBlock (defBody d))
-         $+$ char '}'
+ppDefineSig :: Fmt Define
+ppDefineSig d = "define"
+                <+> ppMaybe ppLinkage (defLinkage d)
+                <+> ppMaybe ppVisibility (defVisibility d)
+                <+> ppType (defRetType d)
+                <+> ppSymbol (defName d)
+                <> ppArgList (defVarArgs d) (map (ppTyped ppIdent) (defArgs d))
+                <+> hsep (ppFunAttr <$> defAttrs d)
+                <+> ppMaybe (\s  -> "section" <+> doubleQuotes (text s)) (defSection d)
+                <+> ppMaybe (\gc -> "gc" <+> ppGC gc) (defGC d)
+                <+> ppMds (defMetadata d)
   where
   ppMds mdm =
     case Map.toList mdm of
       [] -> empty
       mds -> hsep [ "!" <> text k <+> ppValMd md | (k, md) <- mds ]
+
+ppDefine :: Fmt Define
+ppDefine d = ppDefineSig d
+             <+> char '{'
+             $+$ vcat (map ppBasicBlock (defBody d))
+             $+$ char '}'
 
 -- FunAttr ---------------------------------------------------------------------
 
@@ -1580,6 +1586,46 @@ ppDIArgList' pp args = "!DIArgList"
 
 ppDIArgList :: Fmt DIArgList
 ppDIArgList = ppDIArgList' ppLabel
+
+
+-- -------------------------------------------------------------------
+-- Auxiliary pretty-printing functions
+--
+-- These are alternative pretty-printing functions (intead of the pretty-printers
+-- for the basic AST elements above). These functions can be used in
+-- situations where additional or alternative pretty-printing functionality is
+-- needed.
+
+ppModuleAtLines :: (?config :: Config) => String -> Integer -> Fmt Module
+ppModuleAtLines file line =
+  toDoc . atFileLines (AddDocAtLine ?config) (Start empty) file line
+
+data AddDocAtLine = AddDocAtLine Config
+
+data DocBld = Start Doc | DF DocBld Define Doc | BS DocBld (Maybe BlockLabel) Doc
+
+instance AtFileLines DocBld AddDocAtLine where
+  atDefine _ d docbld = DF docbld d empty
+  atBlockStart _ _dr bb docbld = BS docbld (bbLabel bb) empty
+  atStmt (AddDocAtLine c) _dr br s =
+    let isContig = case br of
+          FirstBlockStmt -> True
+          ContiguousStmt -> True
+          FirstLineStmt -> False
+    in withConfig c $ emit $ bool (text "..." $$) (empty $$) isContig $ ppStmt s
+  atGlobal (AddDocAtLine c) g = withConfig c $ emit $ ppGlobal g
+
+emit :: Doc -> DocBld -> DocBld
+emit n = \case
+  DF b s d -> DF b s (d $$ n)
+  BS b l d -> BS b l (d $$ n)
+  Start d -> Start (d $$ n)
+
+toDoc :: Fmt DocBld
+toDoc = \case
+  DF b s d -> toDoc b $$ ppDefineSig s $$ nest 2 d
+  BS b l d -> toDoc b $$ text "" $$ ppMaybe ppLabelDef l $$ d
+  Start d -> d
 
 -- Utilities -------------------------------------------------------------------
 


### PR DESCRIPTION
The ppModuleAtLines allows printing a subset of a function (Define) or a global definition that matches the specified source file and line.