### PR TITLE
Model `dead_on_return` parameter attribute (LLVM 21+)

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -97,6 +97,7 @@ module Text.LLVM.AST
   , defFunType, addDefine
     -- * Function Attributes and attribute groups
   , FunAttr(..)
+  , ParamAttr(..)
     -- * Basic Block Labels
   , BlockLabel(..)
     -- * Basic Blocks
@@ -538,6 +539,10 @@ data PrimType
   | Integer Word32
   | FloatType FloatType
   | X86mmx
+  | X86amx
+  -- ^ Introduced in LLVM 12 (TYPE_CODE_X86_AMX).
+  | Token
+  -- ^ Introduced in LLVM 3.7 (TYPE_CODE_TOKEN).
   | Metadata
     deriving (Data, Eq, Generic, Ord, Show, Lift)
 
@@ -919,6 +924,15 @@ data FunAttr
    | UWTable
   deriving (Data, Eq, Generic, Ord, Show)
 
+-- | Parameter attributes (i.e., attributes that can apply to function
+-- parameters and, in some cases, call-site arguments).
+--
+-- We currently only model the small subset needed by SAW's LLVM pipeline.
+data ParamAttr
+  = DeadOnUnwind  -- ^ Introduced in LLVM 21
+  | DeadOnReturn  -- ^ Introduced in LLVM 22
+  deriving (Data, Eq, Generic, Ord, Show)
+
 -- Basic Block Labels ----------------------------------------------------------
 
 data BlockLabel
@@ -1182,6 +1196,8 @@ data ConvOp
   | PtrToInt
   | IntToPtr
   | BitCast
+  | PtrToAddr
+    -- ^ Pointer-to-address cast. Introduced in LLVM 21.
     deriving (Data, Eq, Generic, Ord, Show)
 
 data AtomicRWOp
@@ -1200,6 +1216,8 @@ data AtomicRWOp
   | AtomicFSub  -- ^ Introduced in LLVM 9
   | AtomicFMax  -- ^ Introduced in LLVM 15
   | AtomicFMin  -- ^ Introduced in LLVM 15
+  | AtomicFMaximum -- ^ Introduced in LLVM 21
+  | AtomicFMinimum -- ^ Introduced in LLVM 21
   | AtomicUIncWrap  -- ^ Introduced in LLVM 16
   | AtomicUDecWrap  -- ^ Introduced in LLVM 16
     deriving (Data, Eq, Enum, Generic, Ord, Show)

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -55,6 +55,7 @@ module Text.LLVM.PP
   , ppDefineSig
   , ppDefine
   , ppFunAttr
+  , ppParamAttr
   , ppLabelDef
   , ppLabel
   , PrettyLabel(ppLabel')
@@ -458,6 +459,8 @@ ppPrimType Void           = "void"
 ppPrimType (Integer i)    = char 'i' <> integer (toInteger i)
 ppPrimType (FloatType ft) = ppFloatType ft
 ppPrimType X86mmx         = "x86mmx"
+ppPrimType X86amx         = "x86_amx"
+ppPrimType Token          = "token"
 ppPrimType Metadata       = "metadata"
 
 ppFloatType :: Fmt FloatType
@@ -614,6 +617,12 @@ ppFunAttr a =
     SSPstrong       -> text "sspstrong"
     UWTable         -> text "uwtable"
 
+ppParamAttr :: Fmt ParamAttr
+ppParamAttr a =
+  case a of
+    DeadOnUnwind -> text "dead_on_unwind"
+    DeadOnReturn -> text "dead_on_return"
+
 -- Basic Blocks ----------------------------------------------------------------
 
 ppLabelDef :: Fmt BlockLabel
@@ -760,6 +769,7 @@ ppConvOp SiToFp   = "sitofp"
 ppConvOp PtrToInt = "ptrtoint"
 ppConvOp IntToPtr = "inttoptr"
 ppConvOp BitCast  = "bitcast"
+ppConvOp PtrToAddr = onlyOnLLVM 21 "PtrToAddr" "ptrtoaddr"
 
 ppAtomicOrdering :: Fmt AtomicOrdering
 ppAtomicOrdering Unordered = text "unordered"
@@ -785,6 +795,8 @@ ppAtomicOp AtomicFAdd = onlyOnLLVM 9 "AtomicFAdd" "fadd"
 ppAtomicOp AtomicFSub = onlyOnLLVM 9 "AtomicFSub" "fsub"
 ppAtomicOp AtomicFMax = onlyOnLLVM 15 "AtomicFMax" "fmax"
 ppAtomicOp AtomicFMin = onlyOnLLVM 15 "AtomicFMin" "fmin"
+ppAtomicOp AtomicFMaximum = onlyOnLLVM 21 "AtomicFMaximum" "fmaximum"
+ppAtomicOp AtomicFMinimum = onlyOnLLVM 21 "AtomicFMinimum" "fminimum"
 ppAtomicOp AtomicUIncWrap = onlyOnLLVM 16 "AtomicUIncWrap" "uinc_wrap"
 ppAtomicOp AtomicUDecWrap = onlyOnLLVM 16 "AtomicUDecWrap" "udec_wrap"
 

--- a/src/Text/LLVM/Parser.hs
+++ b/src/Text/LLVM/Parser.hs
@@ -48,6 +48,8 @@ pPrimType = choice
   , try (string "label")    >> return Label
   , try (string "void")     >> return Void
   , try (string "x86mmx")   >> return X86mmx
+  , try (string "x86_amx")  >> return X86amx
+  , try (string "token")    >> return Token
   , try (string "metadata") >> return Metadata
   ]
 


### PR DESCRIPTION
Adds support for the `dead_on_return` parameter attribute introduced in LLVM 21. Without this, modern Clang/Rust LLVM bitcode that uses the attribute fails to round-trip through `llvm-pretty`.

1 commit, small AST addition + pretty-printing. Independent single-commit PR.