### PR TITLE
Add Token primitive type support

### DIFF
--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -538,6 +538,7 @@ data PrimType
   | Integer Word32
   | FloatType FloatType
   | X86mmx
+  | Token
   | Metadata
     deriving (Data, Eq, Generic, Ord, Show, Lift)
 

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -456,6 +456,7 @@ ppPrimType Void           = "void"
 ppPrimType (Integer i)    = char 'i' <> integer (toInteger i)
 ppPrimType (FloatType ft) = ppFloatType ft
 ppPrimType X86mmx         = "x86mmx"
+ppPrimType Token          = "token"
 ppPrimType Metadata       = "metadata"
 
 ppFloatType :: Fmt FloatType

--- a/src/Text/LLVM/Parser.hs
+++ b/src/Text/LLVM/Parser.hs
@@ -48,6 +48,7 @@ pPrimType = choice
   , try (string "label")    >> return Label
   , try (string "void")     >> return Void
   , try (string "x86mmx")   >> return X86mmx
+  , try (string "token")    >> return Token
   , try (string "metadata") >> return Metadata
   ]
 


### PR DESCRIPTION
Adds AST + pretty-printing for the LLVM `token` primitive type, used by SEH funclet bundles, coroutine intrinsics, and a few other LLVM features. Without this, bitcode that mentions `token` types fails to round-trip.

1 commit, AST-only addition. Filed as draft for upstream consideration — `saw/seh-ast-only` (the main SEH PR) does not require this since SEH funclet tokens can also be carried via the existing operand-bundle path. Open this PR mainly to surface the design choice for upstream feedback.