### PR TITLE
Adds llvmModuleCombine functionality and deprecates the Module semigroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## next (MAJOR)
 
+* Add `LLVM.Combine` module with `llvmModuleCombine` function.  This is the
+  proper way to combine two LLVM `Module` definitions and maintain integrity
+  (e.g. roughly equivalent to `llvm-link`).  The `Module` Semigroup instance is
+  unsafe and is deprecated (along with the Monoid instance) and scheduled for
+  removal.  Note that `llvmModuleCombine` does not do significant error detection
+  and it's up to the caller to determine that the modules should be combined.
+  See the documentation for `llvmModuleCombine` for more details.
+
 * Support LLVM 22:
   * `DICompileUnit'` now has an additional `dicuSourceLanguageVersion :: Word64`
     field.

--- a/llvm-pretty.cabal
+++ b/llvm-pretty.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       2.2
 Name:                llvm-pretty
-Version:             0.14.0.0.100
+Version:             0.14.0.0.101
                      -- TODO: needs to be 0.15 due to UnnamedMdIdx newtype wrapper
 License:             BSD-3-Clause
 License-file:        LICENSE
@@ -39,6 +39,7 @@ Library
                        Text.LLVM.Lens
                        Text.LLVM.Parser
                        Text.LLVM.PP
+                       Text.LLVM.Combine
                        Text.LLVM.DebugUtils
                        Text.LLVM.Triple
                        Text.LLVM.Triple.AST
@@ -67,6 +68,7 @@ Test-suite llvm-pretty-test
   Type: exitcode-stdio-1.0
   Main-is: Main.hs
   Other-modules:
+    CombineTests
     DataLayout
     Metadata
     Output
@@ -78,6 +80,7 @@ Test-suite llvm-pretty-test
   Build-depends:
     llvm-pretty,
     base,
+    microlens,
     pretty,
     tasty,
     tasty-hunit,

--- a/src/Text/LLVM.hs
+++ b/src/Text/LLVM.hs
@@ -141,8 +141,40 @@ nextName pfx ns =
 -- LLVM Monad ------------------------------------------------------------------
 
 newtype LLVM a = LLVM
-  { unLLVM :: WriterT Module (StateT Names Id) a
+  { unLLVM :: WriterT ModuleBuilder (StateT Names Id) a
   } deriving (Functor,Applicative,Monad,MonadFix)
+
+
+-- | This is an internal object used to provide the Monoid/Semigroup building
+-- context for the WriterT.  There is no Semigroup instance for Module itself,
+-- because combining modules is not a trivial operation and it can fail
+-- (e.g. duplicate symbols/definitions); see the 'LLVM.Combine' module for a
+-- proper link-like combining function.  However, the functionality here is not
+-- really combining two modules, but instead is constructing a single module from
+-- discrete operations and thus we can use the ModuleBuilder newtype wrapper to
+-- allow Monoid/Semigroup functionality under this LLVM monad.
+
+newtype ModuleBuilder = ModuleBuilder { getModule :: Module }
+
+instance Semigroup ModuleBuilder where
+  (ModuleBuilder m1) <> (ModuleBuilder m2) = ModuleBuilder $ Module
+    { modSourceName = modSourceName m1 `mplus` modSourceName m2
+    , modTriple = modTriple m1 <> modTriple m2
+    , modDataLayout = modDataLayout m1 <> modDataLayout m2
+    , modTypes = modTypes m1 <> modTypes m2
+    , modUnnamedMd = modUnnamedMd m1 <> modUnnamedMd m2
+    , modNamedMd = modNamedMd m1 <> modNamedMd m2
+    , modGlobals = modGlobals m1 <> modGlobals m2
+    , modDeclares = modDeclares m1 <> modDeclares m2
+    , modDefines = modDefines m1 <> modDefines m2
+    , modInlineAsm = modInlineAsm m1 <> modInlineAsm m2
+    , modAliases = modAliases m1 <> modAliases m2
+    , modComdat = modComdat m1 <> modComdat m2
+    }
+
+instance Monoid ModuleBuilder where
+  mempty = ModuleBuilder emptyModule
+
 
 freshNameLLVM :: String -> LLVM String
 freshNameLLVM pfx = LLVM $ do
@@ -152,24 +184,24 @@ freshNameLLVM pfx = LLVM $ do
   return n
 
 runLLVM :: LLVM a -> (a,Module)
-runLLVM  = fst . runId . runStateT Map.empty . runWriterT . unLLVM
+runLLVM  = fmap getModule . fst . runId . runStateT Map.empty . runWriterT . unLLVM
 
 emitTypeDecl :: TypeDecl -> LLVM ()
-emitTypeDecl td = LLVM (put emptyModule { modTypes = [td] })
+emitTypeDecl td = LLVM (put $ ModuleBuilder $ emptyModule { modTypes = [td] })
 
 emitGlobal :: Global -> LLVM (Typed Value)
 emitGlobal g =
-  do LLVM (put emptyModule { modGlobals = [g] })
+  do LLVM (put $ ModuleBuilder $ emptyModule { modGlobals = [g] })
      return (ptrT (globalType g) -: globalSym g)
 
 emitDefine :: Define -> LLVM (Typed Value)
 emitDefine d =
-  do LLVM (put emptyModule { modDefines = [d] })
+  do LLVM (put $ ModuleBuilder $ emptyModule { modDefines = [d] })
      return (defFunType d -: defName d)
 
 emitDeclare :: Declare -> LLVM (Typed Value)
 emitDeclare d =
-  do LLVM (put emptyModule { modDeclares = [d] })
+  do LLVM (put $ ModuleBuilder $ emptyModule { modDeclares = [d] })
      return (decFunType d -: decName d)
 
 alias :: Ident -> Type -> LLVM ()

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -247,7 +247,7 @@ data Module = Module
 instance
 #if __GLASGOW_HASKELL__ >= 910
   -- Deprecation of instances was added in GHC 9.10
- {-# DEPRECATED "Unsafe! use llvmModuleCombine instead" #-}
+ {-# DEPRECATED "Unsafe! Scheduled for removal: use llvmModuleCombine instead" #-}
 #endif
   Sem.Semigroup Module where
   m1 <> m2 = Module

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -247,7 +247,7 @@ data Module = Module
 instance
 #if __GLASGOW_HASKELL__ >= 910
   -- Deprecation of instances was added in GHC 9.10
- {-# DEPRECATED "Unsafe! use llvm-combine library instead" #-}
+ {-# DEPRECATED "Unsafe! use llvmModuleCombine instead" #-}
 #endif
   Sem.Semigroup Module where
   m1 <> m2 = Module

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -10,6 +10,7 @@ incomplete: there are some values that new LLVM versions would accept but are
 not yet represented here.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -243,7 +244,12 @@ data Module = Module
   } deriving (Data, Eq, Ord, Generic, Show)
 
 -- | Combines fields pointwise.
-instance Sem.Semigroup Module where
+instance
+#if __GLASGOW_HASKELL__ >= 910
+  -- Deprecation of instances was added in GHC 9.10
+ {-# DEPRECATED "Unsafe! use llvm-combine library instead" #-}
+#endif
+  Sem.Semigroup Module where
   m1 <> m2 = Module
     { modSourceName = modSourceName m1 `mplus`   modSourceName m2
     , modTriple     = modTriple m1     <> modTriple     m2
@@ -259,9 +265,13 @@ instance Sem.Semigroup Module where
     , modComdat     = modComdat     m1 <> modComdat     m2
     }
 
-instance Monoid Module where
+instance
+#if __GLASGOW_HASKELL__ >= 910
+  -- Deprecation of instances was added in GHC 9.10
+  {-# DEPRECATED "Scheduled for removal: use emptyModule instead" #-}
+#endif
+  Monoid Module where
   mempty = emptyModule
-  mappend = (<>)
 
 emptyModule :: Module
 emptyModule  = Module

--- a/src/Text/LLVM/Combine.hs
+++ b/src/Text/LLVM/Combine.hs
@@ -1,0 +1,217 @@
+{-# LANGUAGE LambdaCase #-}
+
+{- |
+Module      : Text.LLVM.Combine
+Description : Combine LLVM Modules
+License     : BSD3
+Maintainer  : Kevin Quick <kquick@galois.com>
+Stability   : provisional
+
+Thos module provides the ability to smash together LLVM Module specifications to
+provide the ability to load separate LLVM Modules (e.g. bitcode files) and
+analyze them as if they had been linked together as a single program.
+
+-}
+
+module Text.LLVM.Combine
+  (
+    llvmModuleCombine
+  )
+where
+
+import Data.Bool ( bool )
+import Data.Generics.Schemes ( everywhere )
+import Data.Generics.Aliases ( mkT )
+import Lens.Micro
+import Lens.Micro.Extras
+import Data.Function ( on )
+import Data.List ( find )
+import Data.Maybe ( fromMaybe )
+import Data.String ( fromString )
+import Text.LLVM.AST
+import Text.LLVM.Lens
+
+
+-- | Combines LLVM Modules into a single, composite Module.  This is akin to
+-- linking, but just from the perspective of what is needed for program analysis.
+--
+-- This differs from `llvm-link` in the following known ways:
+--
+-- 1. The `llvm-link` tool uses structural typing resolution: if two modules
+--    each have a type with the same structure, the resulting module will only
+--    have one type; the name from one of the modules is chosen and all
+--    references to the typename in the other module will be rewritten to the
+--    first module.
+--
+--    The `llvmModuleCombine` takes a slightly different approach: types are not
+--    structurally coalesced, but this means that type names are deconflicted by
+--    adding a numbered suffix.  This still requires modifying the type name
+--    throughout that module, but (a) there are probably fewer type name
+--    conflicts than structural equivalences, and (b) the original name is still
+--    part of the new name which maintains origin information.
+--
+-- 2. The `llvm-link` tool will occasionally rewrite calls to llvm intrinsics to
+--    explicitly add the default personality specification.  For example,
+--    `llvm.stacksave` may be rewritten to `llvm.stacksave.p0`.  Because these
+--    are intrinsics, this should not have any significant impact on the result,
+--    but `llvmModuleCombine` does not perform this naming update.
+--
+-- 3. External declaration resolution is type independent and only name
+--    sensitive.  If Module A has an external declaration `declare @f(i32 x)` and
+--    Module B has a definition `define @f(float x)`, this `llvmModuleCombine`
+--    operation will use the latter to satisfy the former (by removing the
+--    former) even though the types do not match.
+--
+llvmModuleCombine :: Module -> Module -> Module
+llvmModuleCombine a addModule =
+  let defs = a ^. modDefinesLens
+      decls = a ^. modDeclaresLens
+      newDefs = b ^. modDefinesLens
+      newDecls = b ^. modDeclaresLens
+      rmvDefined = flip (foldr removeDefined)
+      newDeclsLessOldDefs = rmvDefined defs newDecls
+      oldDeclsLessNewDefs = rmvDefined newDefs decls
+      joinedName n = Just $ fromMaybe "..." n <> "+" <> fromMaybe "..." (modSourceName b)
+      newUmdBase = let umIdxs = umIndex <$> modUnnamedMd a
+                   in bool (succ $ maximum umIdxs) (UnnamedMdIdx 0) $ null umIdxs
+      -- unnamed metadata is referenced almost everywhere, so update that globally
+      -- first:
+      b = updateUmd newUmdBase (deConflictTypes addModule (a ^. modTypesLens))
+  in a
+     & modSourceNameLens %~ joinedName
+     & modDeclaresLens .~ (oldDeclsLessNewDefs <> newDeclsLessOldDefs)
+     & modDefinesLens %~ deConflict (b ^. modDefinesLens)
+     & modTypesLens <>~ b ^. modTypesLens
+     & modUnnamedMdLens <>~ b ^. modUnnamedMdLens
+     & modNamedMdLens <>~ b ^. modNamedMdLens
+     & modComdatLens <>~ b ^. modComdatLens
+     & modGlobalsLens <>~ b ^. modGlobalsLens
+     & modInlineAsmLens <>~ b ^. modInlineAsmLens
+     & modAliasesLens <>~ b ^. modAliasesLens
+  -- TODO Globals any should override Linkage external for the same name
+  -- TODO verify modTriple and modDataLayout are the same?
+
+
+-- | Rewrites type references in the input module to ensure uniqueness against
+-- all types mentioned in the second module.
+deConflictTypes :: Module -> [TypeDecl] -> Module
+deConflictTypes inpMod existingTypes =
+  let resolveTypeConflict m t =
+        if any (((==) `on` typeName) t) existingTypes
+        then renameType m t (let Ident n = typeName t in n <> "___") (0 :: Int)
+        else m
+      renameType m t b n =
+        let newName = Ident (b <> show n)
+        in if any ((newName ==) . typeName) existingTypes
+           then if n > 100000
+                then error $ "Unable to generate unique type name for " <> b
+                else renameType m t b $ succ n
+           else everywhere (mkT (chngType (typeName t) newName)) m
+      chngType oldName newName n = bool n newName $ n == oldName
+  in foldl resolveTypeConflict inpMod (inpMod ^. modTypesLens)
+
+
+-- | A Define takes precedence over a Declare.  When combining modules, module A
+-- may Declare a function that is handled by a Define in module B, so get rid of
+-- the Declare when putting A and B together.
+
+removeDefined :: Define -> [Declare] -> [Declare]
+removeDefined def = filter ((def ^. defNameLens /=) . view decNameLens)
+
+
+-- | Module A and Module B may have a Define with the same name (Symbol).  This
+-- is normal when linking multiple modules together, and is resolved by linkers
+-- as guided by the Linkage information for the two Definitions, usually by
+-- either renaming or merging.
+
+deConflict :: [Define] -> [Define] -> [Define]
+deConflict new curr = uncurry (<>) $ foldl deConflictDef (curr, new) new
+  where
+    deConflictDef (ads, bds) bd =
+      case find (((==) `on` defName) bd) ads of
+        Nothing -> (ads, bds)
+        Just ad -> handle ads bds ad bd
+    handle ads bds ad bd =
+      case bd ^. defLinkageLens of
+        Just Private -> (ads, renameDef bd (view defNameLens <$> ads) bds)
+        Just LinkerPrivate -> (ads, renameDef bd (view defNameLens <$> ads) bds)
+        Just LinkerPrivateWeak ->
+          (ads, renameDef bd (view defNameLens <$> ads) bds) -- ??
+        Just LinkerPrivateWeakDefAuto ->
+          (ads, renameDef bd (view defNameLens <$> ads) bds) -- ??
+        Just Internal -> (ads, renameDef bd (view defNameLens <$> ads) bds)
+        Just AvailableExternally ->
+          -- Never happen: not allowed on defines.  Ignore
+          (ads, bds)
+        Just Linkonce -> (mergeDef ad bd ads, removeDef bd bds)
+        Just Weak -> (mergeDef ad bd ads, removeDef bd bds)
+        Just Common -> (mergeDef ad bd ads, removeDef bd bds)
+        Just ExternWeak -> (mergeDef ad bd ads, removeDef bd bds)
+        Just LinkonceODR -> (mergeDef ad bd ads, removeDef bd bds)
+        Just WeakODR -> (mergeDef ad bd ads, removeDef bd bds)
+        Just Appending -> (appendDef ad bd ads, removeDef bd bds)
+        Just External ->
+          -- This should never happen: it is truly a symbol conflict.  A
+          -- linker would reject this, but here we will just preserve the
+          -- original.
+          (ads, removeDef bd bds)
+        Just DLLImport -> (ads, removeDef bd bds) -- ??
+        Just DLLExport -> (ads, removeDef bd bds) -- ??
+        Nothing ->
+          -- No linkage specified.  The default is 'External', with associated
+          -- considerations as documented for that case above.
+          (ads, removeDef bd bds)
+
+-- Note: Used for Linkonce, Weak, Common, ExternWeak, LinkonceODR, WeakODR. LLVM
+-- docs say "merged", but also indicates that maybe there is a replacement
+-- instead?  For now, treat "merged" as appending.
+mergeDef :: Define -> Define -> [Define] -> [Define]
+mergeDef = appendDef
+
+appendDef :: Define -> Define -> [Define] -> [Define]
+appendDef d1 d2 =
+  let appenD = d1 & defBodyLens <>~ d2 ^. defBodyLens
+  in (appenD :) . filter (((/=) `on` defName) d1)
+
+removeDef :: Define -> [Define] -> [Define]
+removeDef d = filter (((/=) `on` defName) d)
+
+
+-- Renames the Defined symbol to a new name using a discriminator to avoid a
+-- conflict.  Only valid for renaming Private/Internal Defines such that changing
+-- any reference to the original Symbol to the new Symbol in the provided set of
+-- Defines is sufficient to change all references.  Note therefore this excludes:
+-- renaming of global variables, changing a GlobalAlias.
+
+renameDef :: Define -> [Symbol] -> [Define] -> [Define]
+renameDef toRename known inDefs =
+  -- KWQ TODO: needs to change GlobalAlias aliasName?
+  --
+  let getNewName nm n =
+        -- Note: adds a "discriminator" to the name in a way that is valid for
+        -- both C functions and C++ mangled names (see
+        -- https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling-scope).
+        let nn = if n < 10
+                 then nm <> "_" <> show n
+                 else nm <> "__" <> show n <> "_"
+        in case find ((fromString nn ==) . defName) inDefs of
+             Just _ -> getNewName nm $ succ n
+             Nothing ->
+               if fromString nn `elem` known
+               then getNewName nm $ succ n
+               else nn
+      (Symbol oldname) = defName toRename
+      newName = Symbol $ getNewName oldname (1 :: Integer)
+  in changeSym (defName toRename) newName inDefs
+
+
+changeSym :: Symbol -> Symbol -> [Define] -> [Define]
+changeSym old new = everywhere (mkT chngSym)
+  where
+    chngSym s = bool s new $ old == s
+
+-- | Adjusts all unnamed metadata indices in the Module to begin at the specified
+-- newBase, which allows this module to be combined without conflict with a
+-- module whose metadata indices are all below the newBase.
+updateUmd :: UnnamedMdIdx -> Module -> Module
+updateUmd newBase = everywhere (mkT (\n -> n + newBase))

--- a/src/Text/LLVM/Combine.hs
+++ b/src/Text/LLVM/Combine.hs
@@ -7,8 +7,8 @@ License     : BSD3
 Maintainer  : Kevin Quick <kquick@galois.com>
 Stability   : provisional
 
-Thos module provides the ability to smash together LLVM Module specifications to
-provide the ability to load separate LLVM Modules (e.g. bitcode files) and
+This module provides the ability to smash together LLVM 'Module' specifications
+to provide the ability to load separate LLVM 'Module's (e.g. bitcode files) and
 analyze them as if they had been linked together as a single program.
 
 -}
@@ -32,7 +32,7 @@ import Text.LLVM.AST
 import Text.LLVM.Lens
 
 
--- | Combines LLVM Modules into a single, composite Module.  This is akin to
+-- | Combines LLVM 'Module's into a single, composite 'Module'.  This is akin to
 -- linking, but just from the perspective of what is needed for program analysis.
 --
 -- This differs from `llvm-link` in the following known ways:
@@ -43,12 +43,12 @@ import Text.LLVM.Lens
 --    references to the typename in the other module will be rewritten to the
 --    first module.
 --
---    The `llvmModuleCombine` takes a slightly different approach: types are not
---    structurally coalesced, but this means that type names are deconflicted by
---    adding a numbered suffix.  This still requires modifying the type name
---    throughout that module, but (a) there are probably fewer type name
---    conflicts than structural equivalences, and (b) the original name is still
---    part of the new name which maintains origin information.
+--    The `llvmModuleCombine` function takes a slightly different approach: types
+--    are not structurally coalesced, but this means that type names are
+--    deconflicted by adding a numbered suffix.  This still requires modifying
+--    the type name throughout that module, but (a) there are probably fewer type
+--    name conflicts than structural equivalences, and (b) the original name is
+--    still part of the new name which maintains origin information.
 --
 -- 2. The `llvm-link` tool will occasionally rewrite calls to llvm intrinsics to
 --    explicitly add the default personality specification.  For example,
@@ -57,10 +57,10 @@ import Text.LLVM.Lens
 --    but `llvmModuleCombine` does not perform this naming update.
 --
 -- 3. External declaration resolution is type independent and only name
---    sensitive.  If Module A has an external declaration `declare @f(i32 x)` and
---    Module B has a definition `define @f(float x)`, this `llvmModuleCombine`
---    operation will use the latter to satisfy the former (by removing the
---    former) even though the types do not match.
+--    sensitive.  If 'Module' A has an external declaration `declare @f(i32 x)`
+--    and 'Module' B has a definition `define @f(float x)`, then this
+--    `llvmModuleCombine` operation will use the latter to satisfy the former (by
+--    removing the former) even though the types do not match.
 --
 llvmModuleCombine :: Module -> Module -> Module
 llvmModuleCombine a addModule =
@@ -111,18 +111,18 @@ deConflictTypes inpMod existingTypes =
   in foldl resolveTypeConflict inpMod (inpMod ^. modTypesLens)
 
 
--- | A Define takes precedence over a Declare.  When combining modules, module A
--- may Declare a function that is handled by a Define in module B, so get rid of
--- the Declare when putting A and B together.
+-- | A 'Define' takes precedence over a 'Declare'.  When combining modules,
+-- module A may 'Declare' a function that is handled by a 'Define' in module B,
+-- so get rid of the 'Declare' when putting A and B together.
 
 removeDefined :: Define -> [Declare] -> [Declare]
 removeDefined def = filter ((def ^. defNameLens /=) . view decNameLens)
 
 
--- | Module A and Module B may have a Define with the same name (Symbol).  This
--- is normal when linking multiple modules together, and is resolved by linkers
--- as guided by the Linkage information for the two Definitions, usually by
--- either renaming or merging.
+-- | 'Module' A and 'Module' B may have a Define with the same name ('Symbol').
+-- This is normal when linking multiple modules together, and is resolved by
+-- linkers as guided by the 'Linkage' information for the two 'Definition's,
+-- usually by either renaming or merging.
 
 deConflict :: [Define] -> [Define] -> [Define]
 deConflict new curr = uncurry (<>) $ foldl deConflictDef (curr, new) new

--- a/test/CombineTests.hs
+++ b/test/CombineTests.hs
@@ -1,0 +1,231 @@
+module CombineTests
+  (
+    tests
+  )
+where
+
+import           Data.Function ( on )
+import           Data.String ( fromString )
+import           Lens.Micro
+
+import qualified Test.Tasty as Tasty
+import           Test.Tasty.HUnit ( assertBool, testCase, (@?=) )
+
+import           Text.LLVM -- ( emptyModule )
+import           Text.LLVM.Combine
+import           Text.LLVM.Lens
+
+
+tests :: Tasty.TestTree
+tests = Tasty.testGroup "LLVM combine"
+  [
+    testCase "empty equivalences"
+    $ let llvm1 = emptyModule
+          llvm2 = emptyModule
+          llvm3 = emptyModule
+          llvmAll = llvmModuleCombine (llvmModuleCombine llvm1 llvm2) llvm3
+      in assertBool "combining empty is empty"
+         $ and [ llvm1 == llvm1
+               , ((==) `on` (modSourceNameLens .~ Nothing)) llvmAll llvm1
+               , ((==) `on` (modSourceNameLens .~ Nothing)) llvmAll llvm2
+               , ((==) `on` (modSourceNameLens .~ Nothing)) llvmAll llvm3
+               ]
+
+  , testCase "metadata updates"
+    $ let llvm1 = emptyModule
+                  & modUnnamedMdLens .~ [ UnnamedMd { umIndex = 1
+                                                    , umValues = ValMdString "a"
+                                                    , umDistinct = False
+                                                    }
+                                        ]
+                  & modNamedMdLens .~ [ NamedMd { nmName = "frog"
+                                                , nmValues = [1]
+                                                }
+                                      ]
+          llvm2 = emptyModule
+                  & modUnnamedMdLens .~ [ UnnamedMd { umIndex = 1
+                                                    , umValues = ValMdString "B"
+                                                    , umDistinct = False
+                                                    }
+                                        , UnnamedMd { umIndex = 2
+                                                    , umValues = ValMdRef 1
+                                                    , umDistinct = False
+                                                    }
+                                        ]
+                  & modNamedMdLens .~ [ NamedMd { nmName = "pig"
+                                                , nmValues = [2, 1]
+                                                }
+                                      ]
+          llvmAll = llvmModuleCombine llvm1 llvm2
+    in do llvmAll ^. modUnnamedMdLens @?=
+            [ UnnamedMd { umIndex = 1
+                        , umValues = ValMdString "a"
+                        , umDistinct = False
+                        }
+            , UnnamedMd { umIndex = 3
+                        , umValues = ValMdString "B"
+                        , umDistinct = False
+                        }
+            , UnnamedMd { umIndex = 4
+                        , umValues = ValMdRef 3
+                        , umDistinct = False
+                        }
+            ]
+          llvmAll ^. modNamedMdLens @?=
+            [ NamedMd { nmName = "frog"
+                      , nmValues = [1]
+                      }
+            , NamedMd { nmName = "pig"
+                      , nmValues = [4, 3]
+                      }
+            ]
+
+  , testCase "type name deconflicting"
+    $ let llvm1 = emptyModule
+            & modTypesLens .~ [ TypeDecl { typeName = fromString "type1"
+                                         , typeValue = Opaque }
+                              , TypeDecl { typeName = fromString "type1___0"
+                                         , typeValue = Alias $ fromString "cow"
+                                         }
+                              ]
+          llvm2 = emptyModule
+            & modTypesLens .~ [ TypeDecl { typeName = fromString "type1"
+                                         , typeValue = PrimType Void
+                                         }
+                              , TypeDecl { typeName = fromString "type1___0"
+                                         , typeValue = Alias $ fromString "moo"
+                                         }
+                              , TypeDecl { typeName = fromString "type2"
+                                         , typeValue = PtrOpaque
+                                         }
+                              ]
+            & modDefinesLens .~
+            [
+              Define { defName = fromString "foo"
+                     , defLinkage = Nothing
+                     , defVisibility = Nothing
+                     , defComdat = Nothing
+                     , defMetadata = mempty
+                     , defGC = Nothing
+                     , defSection = Nothing
+                     , defVarArgs = False
+                     , defArgs =
+                         [ Typed { typedType = Alias $ fromString "moo"
+                                 , typedValue = fromString "type1___0"
+                                 }
+                         ]
+                     , defRetType = PrimType Void
+                     , defAttrs = mempty
+                     , defBody = []
+                     }
+            ]
+          llvmAll = llvmModuleCombine llvm1 llvm2
+    in do llvmAll ^. modTypesLens @?=
+            [ TypeDecl { typeName = fromString "type1"
+                       , typeValue = Opaque }
+            , TypeDecl { typeName = fromString "type1___0"
+                       , typeValue = Alias $ fromString "cow"
+                       }
+            , TypeDecl { typeName = fromString "type1___1"
+                      , typeValue = PrimType Void
+                      }
+            , TypeDecl { typeName = fromString "type1___0___0"
+                       , typeValue = Alias $ fromString "moo"
+                       }
+            , TypeDecl { typeName = fromString "type2"
+                       , typeValue = PtrOpaque
+                       }
+            ]
+          llvmAll ^. modDefinesLens @?=
+            [
+              Define { defName = fromString "foo"
+                     , defLinkage = Nothing
+                     , defVisibility = Nothing
+                     , defComdat = Nothing
+                     , defMetadata = mempty
+                     , defGC = Nothing
+                     , defSection = Nothing
+                     , defVarArgs = False
+                     , defArgs =
+                         [ Typed { typedType = Alias $ fromString "moo"
+                                 , typedValue = fromString "type1___0___0"
+                                 }
+                         ]
+                     , defRetType = PrimType Void
+                     , defAttrs = mempty
+                     , defBody = []
+                     }
+            ]
+  , testCase "internal define name deconflicting"
+    $ let d1 = Define { defName = fromString "foo"
+                           , defLinkage = Just Internal
+                           , defVisibility = Nothing
+                           , defComdat = Nothing
+                           , defMetadata = mempty
+                           , defGC = Nothing
+                           , defSection = Nothing
+                           , defVarArgs = False
+                           , defArgs =
+                             [ Typed { typedType = Alias $ fromString "moo"
+                                     , typedValue = fromString "type1"
+                                     }
+                             ]
+                           , defRetType = PrimType $ Integer 8
+                           , defAttrs = mempty
+                           , defBody = []
+                           }
+          d2 = Define { defName = fromString "foo"
+                      , defLinkage = Just Internal
+                      , defVisibility = Nothing
+                      , defComdat = Nothing
+                      , defMetadata = mempty
+                      , defGC = Nothing
+                      , defSection = Nothing
+                      , defVarArgs = False
+                      , defArgs = []
+                      , defRetType = PrimType Void
+                      , defAttrs = mempty
+                      , defBody = []
+                           }
+          llvm1 = emptyModule & modDefinesLens .~ [ d1 ]
+          llvm2 = emptyModule & modDefinesLens .~ [ d2 ]
+          llvmAll = llvmModuleCombine llvm1 llvm2
+    in do llvmAll ^. modDefinesLens @?=
+            [ d1
+            , d2 & defNameLens .~ fromString "foo_1"
+            ]
+
+  , testCase "declare to define resolution"
+    $ let d1 = Declare { decName = fromString "foo"
+                       , decLinkage = Nothing
+                       , decVisibility = Nothing
+                       , decComdat = Nothing
+                       , decVarArgs = False
+                       , decArgs = [ Alias $ fromString "moo" ]
+                       , decRetType = PrimType $ Integer 8
+                       , decAttrs = mempty
+                       }
+          d2 = Define { defName = fromString "foo"
+                      , defLinkage = Nothing
+                      , defVisibility = Nothing
+                      , defComdat = Nothing
+                      , defMetadata = mempty
+                      , defGC = Nothing
+                      , defSection = Nothing
+                      , defVarArgs = False
+                      , defArgs =
+                           [ Typed { typedType = Alias $ fromString "cow"
+                                   , typedValue = fromString "type1"
+                                   }
+                           ]
+                      , defRetType = PrimType $ Integer 8
+                      , defAttrs = mempty
+                      , defBody = []
+                           }
+          llvm1 = emptyModule & modDeclaresLens .~ [ d1 ]
+          llvm2 = emptyModule & modDefinesLens .~ [ d2 ]
+          llvmAll = llvmModuleCombine llvm1 llvm2
+    in do llvmAll ^. modDefinesLens @?= [ d2 ]
+          llvmAll ^. modDeclaresLens @?= []
+
+  ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import qualified Test.Tasty as Tasty
 
+import qualified CombineTests
 import qualified DataLayout
 import qualified Metadata
 import qualified Output
@@ -14,4 +15,5 @@ main = Tasty.defaultMain $ Tasty.testGroup "LLVM tests"
        , Metadata.tests
        , Output.tests
        , Triple.tests
+       , CombineTests.tests
        ]


### PR DESCRIPTION
Note: this is transplanted to here from SAW as it properly belongs here (I plan to remove the SAW version in favor of this one).  Changes from the SAW version include using syb `everywhere` instead of lens `biplate` because this module doesn't use lens, deprecation of the Semigroup (for high-enough GHC versions), and tests.