### PR TITLE
LLVM 23 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+* Support LLVM 23:
+  * `DIBasicType'` now has additional `dibt{Scope,File,Line}` fields.
+
 ## 0.15.0.0 -- 2026-08-27
 
 * Add `LLVM.Combine` module with `llvmModuleCombine` function.  This is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Support LLVM 23:
   * `DIBasicType'` now has additional `dibt{Scope,File,Line}` fields.
+  * `DICompileUnit'` now has an additional `dicuDialect :: Maybe
+    DwarfLLVMLangDialect` field, where the new `DwarfLLVMLangDialect` data type
+    enumerates all currently supported dialects.
 
 ## 0.15.0.0 -- 2026-08-27
 

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -165,6 +165,7 @@ module Text.LLVM.AST
   , DwarfLang
   , DwarfTag
   , DwarfVirtuality
+  , DwarfLLVMLangDialect(..)
   , DIFlags
   , DIEmissionKind
   , DIBasicType'(..), DIBasicType
@@ -1941,6 +1942,15 @@ type DIEmissionKind = Word8
 dwarf_DW_APPLE_ENUM_KIND_invalid :: Word32
 dwarf_DW_APPLE_ENUM_KIND_invalid = complement (0 :: Word32) -- ~ LLVM 19
 
+-- | An attribute which identifies an execution-model dialect of a source-level
+-- language. Introduced in LLVM 23.
+data DwarfLLVMLangDialect
+  = DwarfLLVMLangDialectSimt
+    -- ^ (0x01) – single-instruction, multiple-thread execution model.
+  | DwarfLLVMLangDialectTile
+    -- ^ (0x02) – tile-based execution model.
+  deriving (Data, Eq, Generic, Ord, Show)
+
 data DIBasicType' lab = DIBasicType
   { dibtTag      :: DwarfTag
   , dibtName     :: String
@@ -2004,6 +2014,8 @@ data DICompileUnit' lab = DICompileUnit
   , dicuSDK                :: Maybe String
   , dicuSourceLanguageVersion :: Word32
     -- ^ added in LLVM 22
+  , dicuDialect :: Maybe DwarfLLVMLangDialect
+    -- ^ added in LLVM 23
   } deriving (Data, Eq, Functor, Generic, Generic1, Ord, Show)
 
 type DICompileUnit = DICompileUnit' BlockLabel

--- a/src/Text/LLVM/AST.hs
+++ b/src/Text/LLVM/AST.hs
@@ -1955,6 +1955,9 @@ data DIBasicType' lab = DIBasicType
   , dibtFlags    :: Maybe DIFlags
   , dibtNumExtraInhabitants :: Word64 -- ^ added in LLVM 20.
   , dibtDataSize :: Word32 -- ^ added in LLVM 22.
+  , dibtScope :: Maybe (ValMd' lab) -- ^ added in LLVM 23.
+  , dibtFile :: Maybe (ValMd' lab) -- ^ added in LLVM 23.
+  , dibtLine :: Word32 -- ^ added in LLVM 23.
   } deriving (Data, Eq, Functor, Generic, Ord, Show)
 
 type DIBasicType = DIBasicType' BlockLabel

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -1507,6 +1507,12 @@ ppDIBasicType' pp bt = "!DIBasicType"
          then pure ("dataSize:" <+> integral (dibtDataSize bt))
          else Nothing
        ]
+       ++
+       when' (llvmVer >= 23)
+       [     (("scope:"          <+>) . ppValMd' pp) <$> (dibtScope bt)
+       ,     (("file:"           <+>) . ppValMd' pp) <$> (dibtFile bt)
+       , pure ("line:"            <+> integral (dibtLine bt))
+       ]
        )
 
 ppDISubrangeType' :: Fmt i -> Fmt (DISubrangeType' i)

--- a/src/Text/LLVM/PP.hs
+++ b/src/Text/LLVM/PP.hs
@@ -130,6 +130,7 @@ module Text.LLVM.PP
   , ppDISubrangeType
   , ppDICompileUnit'
   , ppDICompileUnit
+  , ppDwarfLLVMLangDialect
   , ppFlags
   , ppDICompositeType'
   , ppDICompositeType
@@ -1573,11 +1574,21 @@ ppDICompileUnit' pp cu = "!DICompileUnit"
          then pure ("sourceLanguageVersion:" <+> integral (dicuSourceLanguageVersion cu))
          else Nothing
        ]
+       ++
+       when' (llvmVer >= 23)
+       [     (("dialect:"               <+>) . ppDwarfLLVMLangDialect) <$> (dicuDialect cu)
+       ]
        )
 
 
 ppDICompileUnit :: Fmt DICompileUnit
 ppDICompileUnit = ppDICompileUnit' ppLabel
+
+-- Based on https://llvm.org/docs/SourceLevelDebugging.html#llvm-language-dialect
+ppDwarfLLVMLangDialect :: Fmt DwarfLLVMLangDialect
+ppDwarfLLVMLangDialect = \case
+  DwarfLLVMLangDialectSimt -> "DW_LLVM_LANG_DIALECT_simt"
+  DwarfLLVMLangDialectTile -> "DW_LLVM_LANG_DIALECT_tile"
 
 ppFlags :: Fmt (Maybe String)
 ppFlags mb = doubleQuotes (maybe empty text mb)

--- a/test/Output.hs
+++ b/test/Output.hs
@@ -75,6 +75,7 @@ tests = Tasty.testGroup "LLVM pretty-printing output tests"
                               , dicuSysRoot = Just "the root"
                               , dicuSDK = Just "SDK"
                               , dicuSourceLanguageVersion = 0
+                              , dicuDialect = Nothing
                               }
         dtt = ValMdDebugInfo
               $ DebugInfoTemplateTypeParameter


### PR DESCRIPTION
These two commits are needed for basic LLVM 23 support in `llvm-pretty`, adding support for new types of metadata introduced in that version.